### PR TITLE
Extend configuration format for segment_range to allow for multiple r…

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
@@ -229,9 +229,9 @@ class AllocationsManager(object):
 
             if select.count() == 0:
 
-                range_min, range_max = host_config['segment_range'].split(':')
+                segmentation_ids = self._segmentation_ids(host_config['segment_range'])
 
-                inside = (int(range_min) <= segmentation_id <= int(range_max))
+                inside = segmentation_id in segmentation_ids
 
                 query = (session.query(AllocationsModel).
                          filter_by(network_id=network_id, level=level, segment_type=segment_type,
@@ -254,11 +254,15 @@ class AllocationsManager(object):
     def _allocation_key(self, host_id, level, segment_type):
         return "{}_{}_{}".format(host_id, level, segment_type)
 
-    def _segmentation_ids(self, host_config):
-        segment_range = host_config['segment_range'].split(':')
-        segment_min = int(segment_range[0])
-        segment_max = int(segment_range[1])
-        return set(moves.range(segment_min, segment_max + 1))
+    @staticmethod
+    def _segmentation_ids(host_config):
+        segment_ranges = []
+        for segment in host_config['segment_range'].split(','):
+            segment_range_str = segment.strip().split(':')
+            segment_range = moves.range(int(segment_range_str[0]), int(segment_range_str[1]) + 1)
+            segment_ranges.extend(segment_range)
+
+        return set(segment_ranges)
 
     def _sync_allocations(self):
         LOG.info("Preparing ACI Allocations table")

--- a/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/agent/test_allocations_manager.py
+++ b/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/agent/test_allocations_manager.py
@@ -1,0 +1,39 @@
+# Copyright 2018 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from neutron.tests import base
+
+from networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager import AllocationsManager
+
+
+class AciNeutronAgentTest(base.BaseTestCase):
+    def test_segmentation_ids(self):
+        # test single range
+        r = AllocationsManager._segmentation_ids({'segment_range': '100:110'})
+        self.assertEqual({100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110}, r)
+
+        # test range with one element
+        r = AllocationsManager._segmentation_ids({'segment_range': '100:100'})
+        self.assertEqual({100}, r)
+
+        # test multiple ranges
+        r = AllocationsManager._segmentation_ids({'segment_range': '100:103,110:112'})
+        self.assertEqual({100, 101, 102, 103, 110, 111, 112}, r)
+
+        # test multiple ranges with trailing whitespace foo
+        r = AllocationsManager._segmentation_ids({'segment_range': ' 100:103 ,  110:112 '})
+        self.assertEqual({100, 101, 102, 103, 110, 111, 112}, r)
+
+        # test overlapping range
+        r = AllocationsManager._segmentation_ids({'segment_range': '100:102,101:103'})
+        self.assertEqual({100, 101, 102, 103}, r)


### PR DESCRIPTION
…anges

segment_range can now contain multiple segment ids separated by ',',
also allowing for single items to appear.

E.g. segment_range = 23,42:45,77