### PR TITLE
Fix deletion of networks mistaken as orphans

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/agent/aci_agent.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/agent/aci_agent.py
@@ -217,10 +217,10 @@ class AciNeutronAgent(rpc_api.ACIRpcAPI):
                     else:
                         LOG.warning("Total binding count {}".format(neutron_binding_count))
 
-                        neutron_network_ids = self.agent_rpc.get_network_ids()
-                        neutron_network_count = self.agent_rpc.get_networks_count()
                         bds = self.aci_manager.get_all_bridge_domains()
                         epgs = self.aci_manager.get_all_epgs()
+                        neutron_network_ids = self.agent_rpc.get_network_ids()
+                        neutron_network_count = self.agent_rpc.get_networks_count()
 
                         LOG.info("Currently managing {} neutron networks and {} Bridge domains and {} EPGS"
                                  .format(neutron_network_count, len(bds), len(epgs)))


### PR DESCRIPTION
The cleanup loop reads neutron_networks first from neutron, then reads
configured networks from ACI. This makes it susceptible for a race condition
where during the duration of the neutron read call, new networks could have
been commited to ACI. However the driver deems these networks as orphaned as
its state of the neutron_networks is outdated.  It then proceeds to clean up
these networks.  Switching the read order to reading ACI first, followed by
neutron neutralizes this inconsistency, as neutron then holds additional
networks to ACI which would be re-synced eventually without any side effect.