### PR TITLE
Aci performance improvements

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/common.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/common.py
@@ -41,6 +41,14 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
             return bind_ports
 
+    def get_network_ids(self, context):
+        result = []
+        query = context.session.query(models_v2.Network.id).order_by(models_v2.Network.id)
+        for network in query:
+            result.append(network.id)
+
+        return result
+
 
 def get_network_config():
     return {

--- a/networking_aci/plugins/ml2/drivers/mech_aci/common.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/common.py
@@ -49,6 +49,28 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
         return result
 
+    def get_address_scope_name(self, context, subnet_pool_id):
+        pool = self.get_subnetpool(context, subnet_pool_id)
+
+        if not pool:
+            LOG.warn("Subnet pool {} does not exist".format(subnet_pool_id))
+            return
+
+        try:
+            scope = self.get_address_scope(context, pool['address_scope_id'])
+        except ext_address_scope.AddressScopeNotFound:
+            LOG.warn("Address scope {} does could not be found, check ACI config for correct configuration"
+                     .format(['pool.address_scope_id']))
+            return
+
+        # This may not be needed no address scope not found is caught
+        if not scope:
+            LOG.warn("Address scope {} does not exist, check ACI config for correct configuration"
+                     .format(['pool.address_scope_id']))
+            return
+
+        return scope.get('name')
+
 
 def get_network_config():
     return {
@@ -64,30 +86,6 @@ def get_host_or_host_group(host_id, host_group_config):
             return hostgroup, hostgroup_config
 
     return host_id, None
-
-
-def get_address_scope_name(context, subnet_pool_id):
-    plugin = DBPlugin()
-    pool = plugin.get_subnetpool(context, subnet_pool_id)
-
-    if not pool:
-        LOG.warn("Subnet pool {} does not exist".format(subnet_pool_id))
-        return
-
-    try:
-        scope = plugin.get_address_scope(context, pool['address_scope_id'])
-    except ext_address_scope.AddressScopeNotFound:
-        LOG.warn("Address scope {} does could not be found, check ACI config for correct configuration"
-                 .format(['pool.address_scope_id']))
-        return
-
-    # This may not be needed no address scope not found is caught
-    if not scope:
-        LOG.warn("Address scope {} does not exist, check ACI config for correct configuration"
-                 .format(['pool.address_scope_id']))
-        return
-
-    return scope.get('name')
 
 
 def get_segments(context, network_id):

--- a/networking_aci/plugins/ml2/drivers/mech_aci/rpc_api.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/rpc_api.py
@@ -55,8 +55,8 @@ class ACIRpcAPI(object):
 
 class AgentRpcCallback(object):
 
-    def __init__(self):
-        self.db = common.DBPlugin()
+    def __init__(self, db):
+        self.db = db
         self.context = context.get_admin_context()
         self.tag_plugin = tag_plugin.TagPlugin()
 
@@ -141,7 +141,7 @@ class AgentRpcCallback(object):
             address_scope_name = None
 
             if pool_id:
-                address_scope_name = common.get_address_scope_name(self.context, pool_id)
+                address_scope_name = self.db.get_address_scope_name(self.context, pool_id)
             result['subnets'].append({
                 'id': subnet.get('id'),
                 'network_id': network_id,

--- a/networking_aci/plugins/ml2/drivers/mech_aci/rpc_api.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/rpc_api.py
@@ -92,13 +92,7 @@ class AgentRpcCallback(object):
 
     @log_helpers.log_method_call
     def get_network_ids(self, rpc_context):
-        networks = self.db.get_networks(self.context, fields=['id'])
-
-        result = []
-        for network in networks:
-            result.append(network.get('id'))
-
-        return result
+        return self.db.get_network_ids(self.context)
 
     @log_helpers.log_method_call
     def get_networks_count(self, rpc_context):


### PR DESCRIPTION
Faster `get_network_ids()` in rpc loop and overall better neutron-server performance with no `DBPlugin` spam.