### PR TITLE
Fallback to next APIC on HTTPError or LoginError

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
@@ -19,7 +19,7 @@ from cobra.mit.access import MoDirectory
 from cobra.mit.request import CommitError
 from cobra.mit.request import ConfigRequest
 from cobra.mit.request import DnQuery
-from cobra.mit.session import LoginSession
+from cobra.mit.session import LoginSession, LoginError
 from cobra.mit.request import QueryError
 from cobra.model.fv import Tenant
 from oslo_log import log
@@ -31,7 +31,8 @@ LOG = log.getLogger(__name__)
 
 RETRY_LIMIT = 2
 FALLBACK_EXCEPTIONS = (rexc.ConnectionError, rexc.Timeout,
-                       rexc.TooManyRedirects, rexc.InvalidURL)
+                       rexc.TooManyRedirects, rexc.InvalidURL,
+                       rexc.HTTPError, LoginError)
 requests.packages.urllib3.disable_warnings()
 
 


### PR DESCRIPTION
There are two errors where we want to switch over to the next APIC in
the rotation:

requests.exceptions.HTTPError('503 Server Error: Service Temporarily
Unavailable for url: ...')

LoginError: REST Endpoint user authorization datastore is not
initialized - Check Fabric Membership Status of this fabric node

The HTTPError is more of a catch-all for all HTTP errors. LoginError is
a custom Exception shipped with cobra only inheriting from Exception.