### PR TITLE
Fix another token problem and no unimo query

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
@@ -179,7 +179,7 @@ class CobraClient(object):
         return mo is not None
 
     def uni_mo(self):
-        return self.lookupByDn('uni')
+        return 'uni'
 
     def get_full_tenant(self, tenant_name):
         return self.query("uni/tn-{}".format(tenant_name), subtree="full", single=True)

--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
@@ -80,7 +80,7 @@ def _retry(func):
                 else:
                     # reraise
                     LOG.exception("Commit failed")
-                    raise e
+                    raise
 
             if retry < max_retries:
                 if trigger_login:
@@ -93,7 +93,7 @@ def _retry(func):
                 return wrapper(self, *args, retry=retry + 1, max_retries=max_retries, **kwargs)
             else:
                 LOG.exception("%s", msg)
-                raise e
+                raise
     return wrapper
 
 

--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
@@ -75,7 +75,7 @@ def _retry(func):
             if retry < max_retries:
                 LOG.info("%s - calling login()", msg)
                 self.login()
-                return func(self, *args, retry=retry + 1, max_retries=max_retries, **kwargs)
+                return wrapper(self, *args, retry=retry + 1, max_retries=max_retries, **kwargs)
             else:
                 LOG.error("%s", msg)
                 raise e

--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
@@ -47,7 +47,7 @@ def _retry(func):
 
         try:
             # check if token is still valid
-            token_validity = self.mo_dir.session.refreshTime - time.time()
+            token_validity = (self.mo_dir.session.refreshTime or 0) - time.time()
             if token_validity < cfg.CONF.ml2_aci.reauth_threshold:
                 if token_validity > 1:
                     LOG.debug("Session only valid for %ss, refreshing auth", token_validity)


### PR DESCRIPTION
The first commit should fix the last "token invalid" bug, which causes queries to fail. The second one reduces API load a tiny bit.