### PR TITLE
Fix off-by-one in segment/vlan range calculation

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/common.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/common.py
@@ -178,7 +178,7 @@ def get_host_from_profile(binding_profile, host):
 
 
 def get_set_from_ranges(ranges):
-    """Convert [(a, b), (c, d), ...] to a set of all numbers in these ranges"""
+    """Convert [(a, b), (c, d), ...] to a set of all numbers in these ranges (inclusive)"""
     result = set()
     for range_from, range_to in ranges:
         result |= set(range(range_from, range_to + 1))

--- a/networking_aci/plugins/ml2/drivers/mech_aci/config.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/config.py
@@ -275,7 +275,7 @@ class ACIConfig:
         ranges = []
         for str_range in str_ranges:
             range_from, range_to = str_range.split(":")
-            ranges.append((int(range_from), int(range_to) + 1))
+            ranges.append((int(range_from), int(range_to)))
         return ranges
 
     def _parse_hostgroups(self):


### PR DESCRIPTION
Ranges are converted from ther a:b,c:d,... string format in the config to a
form of [(a, b), (c, d), ...] format to keep in the config. They are
later converted to a set containing all numbers in these ranges. Both
conversion methods accomodated for python's range() being
right-exclusive, so they both added +1 on the right side, which leads to
the off-by-one. We now remove the +1 from the initial conversion.

The intermediate format used here is present because we don't want to
keep the set of all numbers around, as it makes the data structure much
bigger, which is annoying when transporting it via RPC.