### PR TITLE
Scope direct-mode BM-on-ACI to project

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
@@ -15,6 +15,7 @@
 import random
 
 from neutron_lib.db import api as db_api
+from neutron_lib import context
 from neutron.db.models import segment as ml2_models
 from neutron.plugins.ml2 import models
 from oslo_config import cfg
@@ -27,15 +28,21 @@ from networking_aci._i18n import _LI
 from networking_aci.db.models import AllocationsModel, HostgroupModeModel
 from networking_aci.plugins.ml2.drivers.mech_aci.config import ACI_CONFIG
 from networking_aci.plugins.ml2.drivers.mech_aci import common
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import AccessSegmentationIdAllocationPoolExhausted
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import HostAlreadyHasAccessBinding
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import NetworkHasBoundTrunkPorts
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import NetworkUsesDifferentTrunkId
 from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import NoAllocationFoundInMaximumAllowedAttempts
-from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import SegmentExistsWithDifferentSegmentationId
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import TrunkSegmentIdAlreadyInUse
 
 LOG = log.getLogger(__name__)
 CONF = cfg.CONF
 
 
 class AllocationsManager(object):
-    def __init__(self):
+    def __init__(self, db):
+        self.db = db
+
         if CONF.ml2_aci.sync_allocations:
             try:
                 self._sync_allocations()
@@ -226,46 +233,111 @@ class AllocationsManager(object):
             return True
 
     @db_api.retry_db_errors
-    def allocate_baremetal_segment(self, network, hostgroup, physical_network, level, segmentation_id):
-        """Allocate a "baremetal segment" with pre-specified id
+    def allocate_baremetal_segment(self, network, hostgroup, level, segmentation_id):
+        """Allocate a "baremetal segment" (with or without pre-specified id)
 
-        For such a segment we don't use an ACI allocation entry. No extra release method is required,
-        as it works the same way as with _release_vxlan_segment(). If a segment already exists for a
-        given physnet/network combination we raise an exception
+        Baremetal segments are dynamically allocated based on their physnet (physnet name will be
+        $bm_prefix-$project_id). We have two cases:
+
+        Access port: segmentation_id is None, we select it from a predefined pool tied to the hostgroup.
+                     If the (network, physnet) combination already has a segment, return it.
+                     For an existing segment check that the segmentation id is from the access segmentation
+                     pool, if it is not raise an error.
+                     If not, find all ids of existing segments on this physnet and remove the ids
+                     from the pool, then select a free one
+
+        Trunk port: segmentation_id is predefined by user.
+                    Check if (network, physnet) already has a segment - if it has, raise if the
+                    VLAN id is different, else return the segment.
+                    Check if segmentation_id is already used (existing segment for physnet+id).
+                    If no segment exists, create one.
+
+        This means projects will need to provide strong VLAN consistency. ACI-Baremetal hosts have
+        to be bound to the network in the same way: Either in access mode or in trunk mode with the
+        same segmentation id. Having one host as access and a second one as trunk vlan 1000 is not
+        supported, meaning there can only be one segmentation id per (physnet, network) combination.
+
+        We don't use ACI allocation entries for such segments, as the physical_network attribute is
+        dynamic. No extra release method is required, as it works the same way as with
+        _release_vxlan_segment().
         """
+        is_access = segmentation_id is None
+        ctx = context.get_admin_context()
+        session = ctx.session
         segment_type = hostgroup.get('segment_type', 'vlan')
         segment_physnet = hostgroup.get('physical_network')
         network_id = network['id']
+        access_id_pool = common.get_set_from_ranges(hostgroup['baremetal_access_vlan_ranges'])
 
-        session = db_api.get_writer_session()
-        segment = session.query(ml2_models.NetworkSegment).filter_by(segmentation_id=segmentation_id,
-                                                                     physical_network=segment_physnet,
-                                                                     network_type=segment_type,
-                                                                     network_id=network_id,
-                                                                     segment_index=level).first()
+        with db_api.exc_to_retry(sa.exc.IntegrityError), session.begin(subtransactions=True):
+            # 1. check if segment exists
+            existing_segments = (session.query(ml2_models.NetworkSegment)
+                                 .filter_by(network_id=network_id, physical_network=segment_physnet,
+                                            segment_index=level, network_type=segment_type)
+                                 .all())
 
-        if not segment:
-            with session.begin(subtransactions=True):
-                segment = ml2_models.NetworkSegment(
-                    id=uuidutils.generate_uuid(),
-                    network_id=network_id,
-                    network_type=segment_type,
-                    physical_network=segment_physnet,
-                    segmentation_id=segmentation_id,
-                    segment_index=level,
-                    is_dynamic=False
-                )
-                session.add(segment)
-        else:
-            # check segment has correct id
-            if segment.segmentation_id != segmentation_id:
-                raise SegmentExistsWithDifferentSegmentationId(
-                    segmentation_id=segmentation_id,
-                    segment_id=segment.segment_id,
-                    network_id=network_id,
-                    physnet=segment_physnet)
+            if existing_segments:
+                if len(existing_segments) > 1:
+                    LOG.error("Multiple segments exists for network %s physical network %s - Segments %s with ids %s",
+                              network_id, segment_physnet, ", ".join(n.id for n in existing_segments),
+                              ", ".join(n.segmentation_id for n in existing_segments))
+                segment = existing_segments[0]
+                if is_access:
+                    # make sure the segment id is from the right pool
+                    if segment.segmentation_id not in access_id_pool:
+                        raise NetworkHasBoundTrunkPorts(network_id=network_id, segment_id=segment.id,
+                                                        segmentation_id=segment.segmentation_id)
+                else:
+                    # make sure the segment id matches, else it's an affinity error
+                    if segment.segmentation_id != segmentation_id:
+                        raise NetworkUsesDifferentTrunkId(network_id=network_id,
+                                                          segmentation_id=segment.segmentation_id)
+                return segment
 
-        return segment
+            # 2. sanity checks
+            if is_access:
+                # for access mode: check that no other network has bound this in host mode
+                host_segments = self.db.get_hosts_on_physnet(ctx, segment_physnet, level=1,
+                                                             with_segment=True, with_segmentation=True)
+                for far_host, far_segment_id, far_segmentation_id in host_segments:
+                    if far_host in hostgroup['hosts'] and far_segmentation_id in access_id_pool:
+                        raise HostAlreadyHasAccessBinding(host=far_host, segmentation_id=far_segmentation_id,
+                                                          segment_id=far_segment_id)
+            else:
+                # for trunk mode: check segmentation_id is not already in use in physnet
+                existing_segments = (session.query(ml2_models.NetworkSegment)
+                                     .filter_by(segmentation_id=segmentation_id, physical_network=segment_physnet,
+                                                segment_index=level, network_type=segment_type)
+                                     .all())
+                if existing_segments:
+                    raise TrunkSegmentIdAlreadyInUse(segmentation_id=segmentation_id,
+                                                     segment_id=existing_segments[0].id)
+
+            # 3. no segment exists, allocate one
+            if is_access:
+                # find a free vlan id from the pool
+                physnet_segments = (session.query(ml2_models.NetworkSegment)
+                                    .filter_by(physical_network=segment_physnet)
+                                    .all())
+                used_ids = set(n.segmentation_id for n in physnet_segments)
+                possible_ids = access_id_pool - used_ids
+                if not possible_ids:
+                    raise AccessSegmentationIdAllocationPoolExhausted(hostgroup_name=hostgroup['name'],
+                                                                      physical_network=segment_physnet)
+                segmentation_id = random.choice(list(possible_ids))
+
+            segment = ml2_models.NetworkSegment(
+                id=uuidutils.generate_uuid(),
+                network_id=network_id,
+                network_type=segment_type,
+                physical_network=segment_physnet,
+                segmentation_id=segmentation_id,
+                segment_index=level,
+                is_dynamic=False
+            )
+            session.add(segment)
+
+            return segment
 
     def _allocation_key(self, host_id, level, segment_type):
         return "{}_{}_{}".format(host_id, level, segment_type)

--- a/networking_aci/plugins/ml2/drivers/mech_aci/config.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/config.py
@@ -98,6 +98,12 @@ aci_opts = [
                     "written as pc-policy-group:$name (without prefix)"),
     cfg.ListOpt('baremetal_reserved_vlan_ids', default=[],
                 help="List of reserved vlan id ranges in the format of A:B,C:D - e.g 100:107"),
+    cfg.IntOpt('baremetal_encap_blk_start', default=1000),
+    cfg.IntOpt('baremetal_encap_blk_end', default=1999),
+    cfg.ListOpt('baremetal_default_access_vlan_ranges', default=['1800:1999'],
+                help='Default access vlan ranges, must be included in the baremetal encap block. '
+                     'These ranges will be used to allocate VLAN ids for access ports on a '
+                     'per-physdom basis.'),
     cfg.StrOpt('handle_port_update_for_non_baremetal',
                default=False,
                help="Port updates (e.g. binding host removed/changed) are only handled for trunk ports. "
@@ -135,6 +141,7 @@ hostgroup_opts = [
     cfg.StrOpt('baremetal_pc_policy_group',
                help="(baremetal mode) Section which describes the portchannel policy group attributes. "
                     "If not specified wefall back to default_baremetal_pc_policy_group"),
+    cfg.StrOpt('baremetal_access_vlan_ranges', default=None, help='See baremetal_default_access_vlan_ranges'),
 ]
 
 fixed_binding_opts = [
@@ -305,6 +312,10 @@ class ACIConfig:
             if not hostgroup['baremetal_pc_policy_group']:
                 hostgroup['baremetal_pc_policy_group'] = CONF.ml2_aci.default_baremetal_pc_policy_group
 
+            if not hostgroup['baremetal_access_vlan_ranges']:
+                hostgroup['baremetal_access_vlan_ranges'] = CONF.ml2_aci.baremetal_default_access_vlan_ranges
+            hostgroup['baremetal_access_vlan_ranges'] = self.to_range_list(hostgroup['baremetal_access_vlan_ranges'])
+
     def _parse_fixed_bindings(self):
         self._fixed_bindings = self._parse_config("fixed-binding", fixed_binding_opts, to_dict=True)
 
@@ -359,11 +370,8 @@ class ACIConfig:
                     hg[key] = self.hostgroups[far_hg][key]
                 hg['pc_policy_group'] = hg['infra_pc_policy_group']
             elif hg_mode == aci_const.MODE_BAREMETAL:
-                resource_name = "{}-{}".format(CONF.ml2_aci.baremetal_resource_prefix, name)
-                hg['physical_domain'] = [resource_name]
-                hg['physical_network'] = resource_name
-                hg['baremetal_resource_name'] = resource_name
-                hg['pc_policy_group'] = resource_name
+                node_resource_name = "{}-{}".format(CONF.ml2_aci.baremetal_resource_prefix, name)
+                hg['pc_policy_group'] = node_resource_name
 
                 # bindings do have a different policygroup in baremetal mode
                 for n, binding in enumerate(hg['bindings']):
@@ -387,6 +395,28 @@ class ACIConfig:
 
         return hostgroup
 
+    def annotate_baremetal_info(self, hostgroup, network_id, override_project_id=None):
+        if not (hostgroup['direct_mode'] and hostgroup['hostgroup_mode'] == aci_const.MODE_BAREMETAL):
+            return
+
+        # since baremetal resources are scoped to a project we need to find out if they are in a project
+        ports = self.db.get_ports_on_network_by_physnet_prefix(self.context, network_id, self.baremetal_resource_prefix)
+        project_id = override_project_id
+        for port in ports:
+            if project_id is None:
+                project_id = port['project_id']
+            elif port['project_id'] != project_id:
+                LOG.error("Hostgroup %s has extra port %s in different project (%s vs %s)",
+                          hostgroup['name'], port['port_id'], project_id, port['project_id'])
+
+        if project_id:
+            res_name = self.gen_bm_resource_name(project_id)
+        else:
+            res_name = None
+        hostgroup['baremetal_resource_name'] = res_name
+        hostgroup['physical_domain'] = [res_name]
+        hostgroup['physical_network'] = res_name
+
     def get_hostgroup_name_by_host(self, host_id):
         for hostgroup_name, hostgroup_config in self.hostgroups.items():
             if host_id in hostgroup_config['hosts']:
@@ -398,12 +428,13 @@ class ACIConfig:
             return None, None
         return hostgroup_name, self.get_hostgroup(hostgroup_name, segment_id, level)
 
-    def get_physdoms_by_physnet(self, physnet):
+    def get_physdoms_by_physnet(self, physnet, network_id, override_project_id=None):
         for hg_name, hg in self.hostgroups.items():
             if hg['direct_mode']:
                 # we need mapped values for direct-mode hgs
                 hg = self.get_hostgroup(hg_name)
             if hg['physical_network'] == physnet:
+                self.annotate_baremetal_info(hg, network_id, override_project_id)
                 return hg['physical_domain']
         return []
 
@@ -420,6 +451,13 @@ class ACIConfig:
     def baremetal_reserved_vlans(self):
         ranges = self.to_range_list(CONF.ml2_aci.baremetal_reserved_vlan_ids)
         return common.get_set_from_ranges(ranges)
+
+    @property
+    def baremetal_resource_prefix(self):
+        return "{}-".format(CONF.ml2_aci.baremetal_resource_prefix)
+
+    def gen_bm_resource_name(self, project_id):
+        return "{}{}".format(self.baremetal_resource_prefix, project_id)
 
 
 ACI_CONFIG = ACIConfig()

--- a/networking_aci/plugins/ml2/drivers/mech_aci/exceptions.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/exceptions.py
@@ -19,11 +19,6 @@ class NoAllocationFoundInMaximumAllowedAttempts(exceptions.NeutronException):
     message = "No free allocation could be found within the maximum number of allowed attempts"
 
 
-class SegmentExistsWithDifferentSegmentationId(exceptions.NeutronException):
-    message = ("Segmentation id %(segmentation_id)s already in use by segment %(segment_id)s for "
-               "network %(network_id)s and physnet %(physnet)s")
-
-
 class ACIOpenStackConfigurationError(exceptions.NeutronException):
     message = "%(reason)s"
 
@@ -34,3 +29,39 @@ class TrunkHostgroupNotInBaremetalMode(exceptions.NeutronException):
 
 class TrunkCannotAllocateReservedVlan(exceptions.NeutronException):
     message = "VLAN %(segmentation_id)s is reserved and cannot be allocated by users"
+
+
+class TrunkSegmentationIdNotInAllowedRange(exceptions.NeutronException):
+    message = ("VLAN %(segmentation_id)s is not inside predefined VLAN range "
+               "(needs to be between %(segmentation_start)s and %(segmentation_end)s)")
+
+
+class TrunkSegmentationNotConsistentInProject(exceptions.NeutronException):
+    message = ("Cannot bind subport %(port_id)s: VLAN %(segmentation_id)s is already used in project %(project_id)s in "
+               "network %(network_id)s - you need to provide VLAN consistency inside your project for all "
+               "ACI-connected baremetal servers.")
+
+
+class NetworkHasBoundTrunkPorts(exceptions.NeutronException):
+    message = ("Cannot bind access port in network %(network_id)s as segment %(segment_id)s is already present with "
+               "trunk segmentation id %(segmentation_id)s")
+
+
+class NetworkUsesDifferentTrunkId(exceptions.NeutronException):
+    message = ("Network %(network_id)s has already trunk ports present with id %(segmentation_id)s, please use this id "
+               "to provide VLAN consistency")
+
+
+class TrunkSegmentIdAlreadyInUse(exceptions.NeutronException):
+    message = ("Segmentation id %(segmentation_id)s is already in use by network segment %(segment_id)s, "
+               "cannot repurpose it")
+
+
+class HostAlreadyHasAccessBinding(exceptions.NeutronException):
+    message = ("Host %(host)s already has existing access binding with segmentation id %(segmentation_id)s "
+               "on segment %(segment_id)s")
+
+
+class AccessSegmentationIdAllocationPoolExhausted(exceptions.NeutronException):
+    message = ("Cannot allocate segmentation id for %(hostgroup_name)s - "
+               "the access segmentation id pool for physical network %(physical_network)s is exhausted")


### PR DESCRIPTION
Due to a variety of ACI bugs, limitations, problems and general
unwillingness we can't use the same VLAN from different pools in the
same EPG. This breaks a lot of assumptions the original direct-mode
BM-on-ACI code was based on. But to solve this we are going to...

Instead of creating BM-entities on a per-node basis, all of them are now
created on a per-project basis. We select the project the first
portbinding for a node is made to. The entities are named
`$prefix-$project_id`. This also means we need to redo the lifecycle
management of certain objects:

Networksegments: A networksegment is now created for each
network-project combination with an ACI BM port. When no port remains on
this network-project segment the segment can be deleted. Baremetal
segment allocation has been completely rewritten and an abstract of how
it works now can be found in the docstring of the method.

Binding/VPC infra/BM mode: The mode cannot be switched anymore on
external-API mode switch, as we need to reset it whenever an OpenStack
BM port changes projects (i.e. redeploy of instance). Therefore the
settings are only applied to the VPC when the first port with a host
matching the BM hostgroup is deployed and reset to infra-mode whenever
the last port for this hostgroup is removed. These checks heavily rely
on checking all bindings done to segments for the `$prefix-$project_id`
physical network (aka this is how we find all ports for a node).

Physdom-EPG association: A physdom will be associated to an EPG as long
as there is a port left for it to be mapped.

To implement the new ACI restrictions there are a lot of checks done
both on trunk subport addition and on baremetal segment allocation:
 * projects now have to provide vlan consistency
 * networks cannot have mixed VLANs from same pool anymore

This means if the user chose vlan 1000 for a network, subsequent
portbindings will have to use vlan 1000 for this network as well and
vlan 1000 cannot be used in another project. Also if one network has an
access port no trunk port is allowed in this network and vice versa. If
required, this is something we could - in part (maybe) - work around,
but it was not mentioned as a hard requirement.