### PR TITLE
Scope direct-mode BM-on-ACI to project

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
@@ -15,6 +15,7 @@
 import random
 
 from neutron.db import api as db_api
+from neutron_lib import context
 from neutron.db.models import segment as ml2_models
 from neutron.plugins.ml2 import models
 from oslo_config import cfg
@@ -27,15 +28,21 @@ from networking_aci._i18n import _LI
 from networking_aci.db.models import AllocationsModel, HostgroupModeModel
 from networking_aci.plugins.ml2.drivers.mech_aci.config import ACI_CONFIG
 from networking_aci.plugins.ml2.drivers.mech_aci import common
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import AccessSegmentationIdAllocationPoolExhausted
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import HostAlreadyHasAccessBinding
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import NetworkHasBoundTrunkPorts
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import NetworkUsesDifferentTrunkId
 from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import NoAllocationFoundInMaximumAllowedAttempts
-from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import SegmentExistsWithDifferentSegmentationId
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import TrunkSegmentIdAlreadyInUse
 
 LOG = log.getLogger(__name__)
 CONF = cfg.CONF
 
 
 class AllocationsManager(object):
-    def __init__(self):
+    def __init__(self, db):
+        self.db = db
+
         if CONF.ml2_aci.sync_allocations:
             try:
                 self._sync_allocations()
@@ -226,46 +233,111 @@ class AllocationsManager(object):
             return True
 
     @db_api.retry_db_errors
-    def allocate_baremetal_segment(self, network, hostgroup, physical_network, level, segmentation_id):
-        """Allocate a "baremetal segment" with pre-specified id
+    def allocate_baremetal_segment(self, network, hostgroup, level, segmentation_id):
+        """Allocate a "baremetal segment" (with or without pre-specified id)
 
-        For such a segment we don't use an ACI allocation entry. No extra release method is required,
-        as it works the same way as with _release_vxlan_segment(). If a segment already exists for a
-        given physnet/network combination we raise an exception
+        Baremetal segments are dynamically allocated based on their physnet (physnet name will be
+        $bm_prefix-$project_id). We have two cases:
+
+        Access port: segmentation_id is None, we select it from a predefined pool tied to the hostgroup.
+                     If the (network, physnet) combination already has a segment, return it.
+                     For an existing segment check that the segmentation id is from the access segmentation
+                     pool, if it is not raise an error.
+                     If not, find all ids of existing segments on this physnet and remove the ids
+                     from the pool, then select a free one
+
+        Trunk port: segmentation_id is predefined by user.
+                    Check if (network, physnet) already has a segment - if it has, raise if the
+                    VLAN id is different, else return the segment.
+                    Check if segmentation_id is already used (existing segment for physnet+id).
+                    If no segment exists, create one.
+
+        This means projects will need to provide strong VLAN consistency. ACI-Baremetal hosts have
+        to be bound to the network in the same way: Either in access mode or in trunk mode with the
+        same segmentation id. Having one host as access and a second one as trunk vlan 1000 is not
+        supported, meaning there can only be one segmentation id per (physnet, network) combination.
+
+        We don't use ACI allocation entries for such segments, as the physical_network attribute is
+        dynamic. No extra release method is required, as it works the same way as with
+        _release_vxlan_segment().
         """
+        is_access = segmentation_id is None
+        ctx = context.get_admin_context()
+        session = ctx.session
         segment_type = hostgroup.get('segment_type', 'vlan')
         segment_physnet = hostgroup.get('physical_network')
         network_id = network['id']
+        access_id_pool = common.get_set_from_ranges(hostgroup['baremetal_access_vlan_ranges'])
 
-        session = db_api.get_writer_session()
-        segment = session.query(ml2_models.NetworkSegment).filter_by(segmentation_id=segmentation_id,
-                                                                     physical_network=segment_physnet,
-                                                                     network_type=segment_type,
-                                                                     network_id=network_id,
-                                                                     segment_index=level).first()
+        with db_api.exc_to_retry(sa.exc.IntegrityError), session.begin(subtransactions=True):
+            # 1. check if segment exists
+            existing_segments = (session.query(ml2_models.NetworkSegment)
+                                 .filter_by(network_id=network_id, physical_network=segment_physnet,
+                                            segment_index=level, network_type=segment_type)
+                                 .all())
 
-        if not segment:
-            with session.begin(subtransactions=True):
-                segment = ml2_models.NetworkSegment(
-                    id=uuidutils.generate_uuid(),
-                    network_id=network_id,
-                    network_type=segment_type,
-                    physical_network=segment_physnet,
-                    segmentation_id=segmentation_id,
-                    segment_index=level,
-                    is_dynamic=False
-                )
-                session.add(segment)
-        else:
-            # check segment has correct id
-            if segment.segmentation_id != segmentation_id:
-                raise SegmentExistsWithDifferentSegmentationId(
-                    segmentation_id=segmentation_id,
-                    segment_id=segment.segment_id,
-                    network_id=network_id,
-                    physnet=segment_physnet)
+            if existing_segments:
+                if len(existing_segments) > 1:
+                    LOG.error("Multiple segments exists for network %s physical network %s - Segments %s with ids %s",
+                              network_id, segment_physnet, ", ".join(n.id for n in existing_segments),
+                              ", ".join(n.segmentation_id for n in existing_segments))
+                segment = existing_segments[0]
+                if is_access:
+                    # make sure the segment id is from the right pool
+                    if segment.segmentation_id not in access_id_pool:
+                        raise NetworkHasBoundTrunkPorts(network_id=network_id, segment_id=segment.id,
+                                                        segmentation_id=segment.segmentation_id)
+                else:
+                    # make sure the segment id matches, else it's an affinity error
+                    if segment.segmentation_id != segmentation_id:
+                        raise NetworkUsesDifferentTrunkId(network_id=network_id,
+                                                          segmentation_id=segment.segmentation_id)
+                return segment
 
-        return segment
+            # 2. sanity checks
+            if is_access:
+                # for access mode: check that no other network has bound this in host mode
+                host_segments = self.db.get_hosts_on_physnet(ctx, segment_physnet, level=1,
+                                                             with_segment=True, with_segmentation=True)
+                for far_host, far_segment_id, far_segmentation_id in host_segments:
+                    if far_host in hostgroup['hosts'] and far_segmentation_id in access_id_pool:
+                        raise HostAlreadyHasAccessBinding(host=far_host, segmentation_id=far_segmentation_id,
+                                                          segment_id=far_segment_id)
+            else:
+                # for trunk mode: check segmentation_id is not already in use in physnet
+                existing_segments = (session.query(ml2_models.NetworkSegment)
+                                     .filter_by(segmentation_id=segmentation_id, physical_network=segment_physnet,
+                                                segment_index=level, network_type=segment_type)
+                                     .all())
+                if existing_segments:
+                    raise TrunkSegmentIdAlreadyInUse(segmentation_id=segmentation_id,
+                                                     segment_id=existing_segments[0].id)
+
+            # 3. no segment exists, allocate one
+            if is_access:
+                # find a free vlan id from the pool
+                physnet_segments = (session.query(ml2_models.NetworkSegment)
+                                    .filter_by(physical_network=segment_physnet)
+                                    .all())
+                used_ids = set(n.segmentation_id for n in physnet_segments)
+                possible_ids = access_id_pool - used_ids
+                if not possible_ids:
+                    raise AccessSegmentationIdAllocationPoolExhausted(hostgroup_name=hostgroup['name'],
+                                                                      physical_network=segment_physnet)
+                segmentation_id = random.choice(list(possible_ids))
+
+            segment = ml2_models.NetworkSegment(
+                id=uuidutils.generate_uuid(),
+                network_id=network_id,
+                network_type=segment_type,
+                physical_network=segment_physnet,
+                segmentation_id=segmentation_id,
+                segment_index=level,
+                is_dynamic=False
+            )
+            session.add(segment)
+
+            return segment
 
     def _allocation_key(self, host_id, level, segment_type):
         return "{}_{}_{}".format(host_id, level, segment_type)

--- a/networking_aci/plugins/ml2/drivers/mech_aci/common.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/common.py
@@ -171,9 +171,12 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
                 hosts.add(host)
         return hosts
 
-    def get_segment_ids_by_physnet(self, context, physical_network):
+    def get_segment_ids_by_physnet(self, context, physical_network, fuzzy_match=False):
         query = context.session.query(segment_models.NetworkSegment.id)
-        query = query.filter(segment_models.NetworkSegment.physical_network == physical_network)
+        if fuzzy_match:
+            query = query.filter(segment_models.NetworkSegment.physical_network.like(physical_network))
+        else:
+            query = query.filter(segment_models.NetworkSegment.physical_network == physical_network)
         return [seg.id for seg in query.all()]
 
     def get_ports_on_network_by_physnet_prefix(self, context, network_id, physical_network_prefix):

--- a/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
@@ -13,6 +13,7 @@
 #    under the License.
 from neutron_lib import context
 from neutron_lib import constants as n_const
+from neutron_lib import exceptions as n_exc
 from neutron_lib.plugins.ml2 import api
 from neutron.common import rpc as n_rpc
 from oslo_log import log as logging
@@ -35,9 +36,9 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
         LOG.info(_LI("ACI mechanism driver initializing..."))
         self.topic = None
         self.conn = None
-        self.allocations_manager = allocations.AllocationsManager()
-
         self.db = common.DBPlugin()
+        self.allocations_manager = allocations.AllocationsManager(self.db)
+
         ACI_CONFIG.db = self.db
         self.context = context.get_admin_context_without_session()
         self.rpc_notifier = rpc_api.ACIRpcClientAPI(self.context)
@@ -78,6 +79,11 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
             LOG.warning("No segments found for port %s with host %s - very unusual", port['id'], host)
             return
 
+        # direct baremetal-on-aci needs to be annotated with physnet (and other stuff)
+        if hostgroup['direct_mode']:
+            ACI_CONFIG.annotate_baremetal_info(hostgroup, context.network.current['id'],
+                                               override_project_id=port['project_id'])
+
         # hierarchical or direct?
         if not context.binding_levels:
             self._bind_port_hierarchical(context, port, hostgroup_name, hostgroup)
@@ -115,13 +121,26 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
             segment_id = allocation.segment_id
         else:
             # baremetal objects use a different physnet and gets allocated to its own segment
+            # check that no baremetal-on-aci port from another project is in this network
+            segment_prefix = "{}-".format(CONF.ml2_aci.baremetal_resource_prefix)
+            for seg_port in self.db.get_ports_on_network_by_physnet_prefix(context._plugin_context,
+                                                                           network['id'], segment_prefix):
+                if seg_port['project_id'] != port['project_id']:
+                    msg = ("Cannot bind port {}: Hostgroup {} has baremetal port {} belonging to project {}, "
+                           "new port is from project {} - aborting binding"
+                           .format(port['id'], hostgroup['name'], seg_port['port_id'], seg_port['project_id'],
+                                   port['project_id']))
+                    LOG.error(msg)
+                    raise n_exc.NeutronException(msg)
+
+            ACI_CONFIG.annotate_baremetal_info(hostgroup, network['id'], override_project_id=port['project_id'])
             if aci_const.TRUNK_PROFILE in port['binding:profile']:
                 segmentation_id = port['binding:profile'][aci_const.TRUNK_PROFILE].get('segmentation_id', 1)
             else:
-                segmentation_id = 1  # use vlan 1 access
-            allocation = self.allocations_manager.allocate_baremetal_segment(network, hostgroup, segment_physnet, level,
-                                                                             segmentation_id)
+                segmentation_id = None  # let the allocater choose a vlan
+            allocation = self.allocations_manager.allocate_baremetal_segment(network, hostgroup, level, segmentation_id)
             segment_id = allocation.id
+            segmentation_id = allocation.segmentation_id
 
         if not allocation:
             LOG.error("Binding failed, could not allocate a segment for further binding levels "
@@ -158,7 +177,12 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
                     'segmentation_id': segment['segmentation_id'],
                 }
 
-                if hostgroup['hostgroup_mode'] == aci_const.MODE_BAREMETAL and segment['segmentation_id'] != 1:
+                # annotate baremetal resource name for baremetal group (if necessary)
+                network = context.network.current
+                ACI_CONFIG.annotate_baremetal_info(hostgroup, network['id'], override_project_id=port['project_id'])
+
+                if hostgroup['hostgroup_mode'] == aci_const.MODE_BAREMETAL and \
+                        aci_const.TRUNK_PROFILE in port['binding:profile']:
                     port_type_str = "trunk port"
                 else:
                     port_type_str = "access port"
@@ -279,24 +303,54 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
             return
 
         # Get segment from ml2_port_binding_levels based on segment_id and host
-        # if no ports on this segment for host we can remove the aci allocation
+        # if no ports on this segment for host we can remove the aci allocation.
+        # In baremetal mode we need to call cleanup when the hostgroup is no longer on the physnet
         released = self.allocations_manager.release_segment(network, hostgroup, 1, segment)
-        if not released:
+        if not released and not (hostgroup['direct_mode'] and hostgroup['hostgroup_mode'] == aci_const.MODE_BAREMETAL):
             return
 
         # Call to ACI to delete port if the segment is released i.e.
         # port is the last for the network one on the host
         # Check if physical domain should be cleared
-        clearable_physdoms = self._get_clearable_phys_doms(context, network['id'],
-                                                           segment, hostgroup)
-        self.rpc_notifier.delete_port(port, hostgroup, clearable_physdoms)
+        ACI_CONFIG.annotate_baremetal_info(hostgroup, network['id'], override_project_id=port['project_id'])
+        clearable_physdoms = []
+        if released:
+            # physdoms will only be removed on segment removal
+            clearable_physdoms = self._get_clearable_phys_doms(context, network['id'],
+                                                               segment, hostgroup, port['project_id'])
 
-    def _get_clearable_phys_doms(self, context, network_id, local_segment, host_config):
+        clearable_bm_entities = []
+        reset_bindings_to_infra = False
+        if hostgroup['direct_mode'] and hostgroup['hostgroup_mode'] == aci_const.MODE_BAREMETAL:
+            # if this hostgroup has hosts left we cancel the removal
+            hosts_on_network = self.db.get_hosts_on_network(context, network['id'], level=1)
+            if any(host in hosts_on_network for host in hostgroup['hosts']):
+                return
+
+            # if this hostgroup has no host left on the physnet we can reset the VPC/bindings
+            hosts_on_physnet = self.db.get_hosts_on_physnet(context, hostgroup['physical_network'], level=1)
+            if not any(host in hosts_on_physnet for host in hostgroup['hosts']):
+                reset_bindings_to_infra = True
+
+            # if this port is the last from a project we clear out the bm entities on ACI
+            seg_prefix = ACI_CONFIG.baremetal_resource_prefix
+            projects_on_physnets = self.db.get_bound_projects_by_physnet_prefix(context, seg_prefix)
+            if port['project_id'] not in projects_on_physnets:
+                clearable_bm_entities.append(ACI_CONFIG.gen_bm_resource_name(port['project_id']))
+
+        LOG.debug("Sending RPC delete_port for port %s hostgroup %s with clearable physdoms %s "
+                  "clearable bm-entities %s and reset-bindings-to-infra %s",
+                  port['id'], hostgroup['name'], clearable_physdoms, clearable_bm_entities, reset_bindings_to_infra)
+        self.rpc_notifier.delete_port(port, hostgroup, clearable_physdoms, clearable_bm_entities,
+                                      reset_bindings_to_infra)
+
+    def _get_clearable_phys_doms(self, context, network_id, local_segment, host_config, project_id):
         clearable_physdoms = set(host_config['physical_domain'])
         for other_segment in common.get_segments(context, network_id):
             if other_segment['physical_network'] is None:
                 continue
-            other_physdoms = ACI_CONFIG.get_physdoms_by_physnet(other_segment['physical_network'])
+            other_physdoms = ACI_CONFIG.get_physdoms_by_physnet(other_segment['physical_network'], network_id,
+                                                                project_id)
             if not other_physdoms:
                 LOG.warning("No config found for segment %s physical network %s in network %s",
                             local_segment['id'], other_segment['physical_network'], network_id)

--- a/networking_aci/plugins/ml2/drivers/mech_aci/exceptions.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/exceptions.py
@@ -19,11 +19,6 @@ class NoAllocationFoundInMaximumAllowedAttempts(exceptions.NeutronException):
     message = "No free allocation could be found within the maximum number of allowed attempts"
 
 
-class SegmentExistsWithDifferentSegmentationId(exceptions.NeutronException):
-    message = ("Segmentation id %(segmentation_id)s already in use by segment %(segment_id)s for "
-               "network %(network_id)s and physnet %(physnet)s")
-
-
 class ACIOpenStackConfigurationError(exceptions.NeutronException):
     message = "%(reason)s"
 
@@ -34,3 +29,39 @@ class TrunkHostgroupNotInBaremetalMode(exceptions.NeutronException):
 
 class TrunkCannotAllocateReservedVlan(exceptions.NeutronException):
     message = "VLAN %(segmentation_id)s is reserved and cannot be allocated by users"
+
+
+class TrunkSegmentationIdNotInAllowedRange(exceptions.NeutronException):
+    message = ("VLAN %(segmentation_id)s is not inside predefined VLAN range "
+               "(needs to be between %(segmentation_start)s and %(segmentation_end)s)")
+
+
+class TrunkSegmentationNotConsistentInProject(exceptions.NeutronException):
+    message = ("Cannot bind subport %(port_id)s: VLAN %(segmentation_id)s is already used in project %(project_id)s in "
+               "network %(network_id)s - you need to provide VLAN consistency inside your project for all "
+               "ACI-connected baremetal servers.")
+
+
+class NetworkHasBoundTrunkPorts(exceptions.NeutronException):
+    message = ("Cannot bind access port in network %(network_id)s as segment %(segment_id)s is already present with "
+               "trunk segmentation id %(segmentation_id)s")
+
+
+class NetworkUsesDifferentTrunkId(exceptions.NeutronException):
+    message = ("Network %(network_id)s has already trunk ports present with id %(segmentation_id)s, please use this id "
+               "to provide VLAN consistency")
+
+
+class TrunkSegmentIdAlreadyInUse(exceptions.NeutronException):
+    message = ("Segmentation id %(segmentation_id)s is already in use by network segment %(segment_id)s, "
+               "cannot repurpose it")
+
+
+class HostAlreadyHasAccessBinding(exceptions.NeutronException):
+    message = ("Host %(host)s already has existing access binding with segmentation id %(segmentation_id)s "
+               "on segment %(segment_id)s")
+
+
+class AccessSegmentationIdAllocationPoolExhausted(exceptions.NeutronException):
+    message = ("Cannot allocate segmentation id for %(hostgroup_name)s - "
+               "the access segmentation id pool for physical network %(physical_network)s is exhausted")

--- a/networking_aci/plugins/ml2/drivers/mech_aci/trunk.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/trunk.py
@@ -16,8 +16,11 @@ from networking_aci.plugins.ml2.drivers.mech_aci import common
 from networking_aci.plugins.ml2.drivers.mech_aci.config import ACI_CONFIG
 from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import TrunkHostgroupNotInBaremetalMode
 from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import TrunkCannotAllocateReservedVlan
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import TrunkSegmentationIdNotInAllowedRange
+from networking_aci.plugins.ml2.drivers.mech_aci.exceptions import TrunkSegmentationNotConsistentInProject
 
 
+CONF = cfg.CONF
 LOG = logging.getLogger(__name__)
 
 NAME = 'aci'
@@ -82,9 +85,30 @@ class ACITrunkDriver(base.DriverBase):
         if not (hostgroup['direct_mode'] and hostgroup['hostgroup_mode'] == aci_const.MODE_BAREMETAL):
             raise TrunkHostgroupNotInBaremetalMode(port_id=payload.current_trunk.port_id, hostgroup=hostgroup_name)
 
+        vlan_map = ACI_CONFIG.db.get_trunk_vlan_usage_on_project(ctx, parent['project_id'])
+        bm_access_ranges = common.get_set_from_ranges(hostgroup['baremetal_access_vlan_ranges'])
         for subport in payload.subports:
-            if subport.segmentation_id in ACI_CONFIG.baremetal_reserved_vlans:
+            if subport.segmentation_id in ACI_CONFIG.baremetal_reserved_vlans or \
+                    subport.segmentation_id in bm_access_ranges:
                 raise TrunkCannotAllocateReservedVlan(segmentation_id=subport.segmentation_id)
+
+            # check that we are part of the actual allocated vlan pool
+            if subport.segmentation_id not in range(CONF.ml2_aci.baremetal_encap_blk_start,
+                                                    CONF.ml2_aci.baremetal_encap_blk_end):
+                raise TrunkSegmentationIdNotInAllowedRange(segmentation_id=subport.segmentation_id,
+                                                           segmentation_start=CONF.ml2_aci.baremetal_encap_blk_start,
+                                                           segmentation_end=CONF.ml2_aci.baremetal_encap_blk_end)
+
+            # check if any subport's segmentation id violates vlan consistency
+            # --> in the subport's project no other network is allowed to use the segmentation id
+            if subport.segmentation_id in vlan_map:
+                port = self.core_plugin.get_port(ctx, subport.port_id)
+                nets = vlan_map[subport.segmentation_id]
+                if nets and port['network_id'] not in nets:
+                    raise TrunkSegmentationNotConsistentInProject(segmentation_id=subport.segmentation_id,
+                                                                  project_id=parent['project_id'],
+                                                                  port_id=subport.port_id,
+                                                                  network_id=port['network_id'])
 
     def trunk_create(self, resource, event, trunk_plugin, payload):
         ctx, parent = self._get_context_and_parent_port(payload.current_trunk.port_id)
@@ -155,7 +179,8 @@ class ACITrunkDriver(base.DriverBase):
                 }
             self.core_plugin.update_port(ctx, subport.port_id, port_data)
 
-        if len(trunk.sub_ports) > 0:
+        num_deleted_subports = len(subports) if delete else 0
+        if len(trunk.sub_ports) - num_deleted_subports > 0:
             trunk.update(status=trunk_const.ACTIVE_STATUS)
         else:
             # trunk is automatically set to DOWN on change. if we don't change that it will stay that way


### PR DESCRIPTION
**This is a cherrypick of 24cf839c7687595ee93e14e5f92749eddce6d3ec from ussuri to queens**

--- 

Due to a variety of ACI bugs, limitations, problems and general
unwillingness we can't use the same VLAN from different pools in the
same EPG. This breaks a lot of assumptions the original direct-mode
BM-on-ACI code was based on. But to solve this we are going to...

Instead of creating BM-entities on a per-node basis, all of them are now
created on a per-project basis. We select the project the first
portbinding for a node is made to. The entities are named
`$prefix-$project_id`. This also means we need to redo the lifecycle
management of certain objects:

Networksegments: A networksegment is now created for each
network-project combination with an ACI BM port. When no port remains on
this network-project segment the segment can be deleted. Baremetal
segment allocation has been completely rewritten and an abstract of how
it works now can be found in the docstring of the method.

Binding/VPC infra/BM mode: The mode cannot be switched anymore on
external-API mode switch, as we need to reset it whenever an OpenStack
BM port changes projects (i.e. redeploy of instance). Therefore the
settings are only applied to the VPC when the first port with a host
matching the BM hostgroup is deployed and reset to infra-mode whenever
the last port for this hostgroup is removed. These checks heavily rely
on checking all bindings done to segments for the `$prefix-$project_id`
physical network (aka this is how we find all ports for a node).

Physdom-EPG association: A physdom will be associated to an EPG as long
as there is a port left for it to be mapped.

To implement the new ACI restrictions there are a lot of checks done
both on trunk subport addition and on baremetal segment allocation:
 * projects now have to provide vlan consistency
 * networks cannot have mixed VLANs from same pool anymore

This means if the user chose vlan 1000 for a network, subsequent
portbindings will have to use vlan 1000 for this network as well and
vlan 1000 cannot be used in another project. Also if one network has an
access port no trunk port is allowed in this network and vice versa. If
required, this is something we could - in part (maybe) - work around,
but it was not mentioned as a hard requirement.