### PR TITLE
FIx segment-check in direct-mode switchover API

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/common.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/common.py
@@ -171,9 +171,12 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
                 hosts.add(host)
         return hosts
 
-    def get_segment_ids_by_physnet(self, context, physical_network):
+    def get_segment_ids_by_physnet(self, context, physical_network, fuzzy_match=False):
         query = context.session.query(segment_models.NetworkSegment.id)
-        query = query.filter(segment_models.NetworkSegment.physical_network == physical_network)
+        if fuzzy_match:
+            query = query.filter(segment_models.NetworkSegment.physical_network.like(physical_network))
+        else:
+            query = query.filter(segment_models.NetworkSegment.physical_network == physical_network)
         return [seg.id for seg in query.all()]
 
     def get_ports_on_network_by_physnet_prefix(self, context, network_id, physical_network_prefix):


### PR DESCRIPTION
With the new semgent model the switchover API needs to check if there
are any portbindings left for a hostgroup on ANY baremetal segment, not
just a single segment like in infra mode.