### PR TITLE
Fix field query order for sa 1.2.1 compat

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/common.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/common.py
@@ -182,8 +182,8 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
     def get_ports_on_network_by_physnet_prefix(self, context, network_id, physical_network_prefix):
         # get all ports for a network that are on a segment with a physnet prefix
         fields = [
-            segment_models.NetworkSegment.id, segment_models.NetworkSegment.physical_network,
-            models_v2.Port.id, models_v2.Port.project_id
+            models_v2.Port.id, models_v2.Port.project_id,
+            segment_models.NetworkSegment.id, segment_models.NetworkSegment.physical_network
         ]
         query = context.session.query(*fields)
         query = query.filter(models_v2.Port.network_id == network_id)
@@ -195,10 +195,10 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
         result = []
         for entry in query.all():
             result.append({
-                'segment_id': entry[0],
-                'physical_network': entry[1],
-                'port_id': entry[2],
-                'project_id': entry[3],
+                'port_id': entry[0],
+                'project_id': entry[1],
+                'segment_id': entry[2],
+                'physical_network': entry[3],
             })
 
         return result


### PR DESCRIPTION
With Neutron Ussuri / SqlAlchemy 1.3.1+ the old original field order for
this query worked as intended. With 1.2.1 SqlAlchemy takes the first
field queried as table for the FROM clause. This results in
networksegments being in the FROM clause, causing an SQL error
(1066, "Not unique table/alias: 'networksegments'"). It is very nice
that SA 1.3.1+ can handle this, though from a programming and
code-reading perspective it makes much more sense to pull the port
fields in front of the query. Therefore we'll be doing this patch both
for Ussuri and Queens.