### PR TITLE
Fix providing contract bug on external net create

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
@@ -363,7 +363,7 @@ class CobraManager(object):
             epg_contracts.append(contract)
 
         for provided in scope_config['provided_contracts']:
-            contract = fv.RsCons(epg, provided)
+            contract = fv.RsProv(epg, provided)
             if delete and last_on_network:
                 contract.delete()
             epg_contracts.append(contract)


### PR DESCRIPTION
When an external subnet is created in OpenStack the external network it
belongs to is created/updated and we make sure that it has the
appropriate providing/consuming contracts. Due to a refactor the
creation of providing and consuming contracts were reduced to only
create consuming contracts, which should now have been rectified. This
only causes problem with external networks that have been created after
deployment of this commit, but as there is no syncloop ensuring external
network config these networks need to be synced manually.

The bug was introduced in 5fd5931717e96efe9020d8fc0d948af327284984