### PR TITLE
secure _sync_allocations with retry_db_errors decorator

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
@@ -346,6 +346,7 @@ class AllocationsManager(object):
     def _segmentation_ids(host_config):
         return common.get_set_from_ranges(host_config['segment_range'])
 
+    @db_api.retry_db_errors
     def _sync_allocations(self):
         LOG.info("Preparing ACI Allocations table")
         level = 1  # Currently only supporting one level in hierarchy


### PR DESCRIPTION
_sync_allocations can crash with oslo_db.exception.DBDeadlock if multiple instances of neutron
are spawning simultaniously.

```
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager [req-411b4fab-9e38-404a-908d-47825319a2a7 gNone - - - - -] __init__ sync alloc: oslo_db.exception.DBDeadlock: (pymysql.err.InternalError) (1205, 'Lock wait timeout exceeded; try restarting transaction')
[SQL: SELECT aci_port_binding_allocations.host AS aci_port_binding_allocations_host, aci_port_binding_allocations.level AS aci_port_binding_allocations_level, aci_port_binding_allocations.segment_type AS aci_port_binding_allocations_segment_type, aci_port_binding_allocations.segmentation_id AS aci_port_binding_allocations_segmentation_id, aci_port_binding_allocations.segment_id AS aci_port_binding_allocations_segment_id, aci_port_binding_allocations.network_id AS aci_port_binding_allocations_network_id
FROM aci_port_binding_allocations FOR UPDATE]
(Background on this error at: http://sqlalche.me/e/2j85)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager Traceback (most recent call last):
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     cursor, statement, parameters, context
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/engine/default.py", line 590, in do_execute
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     cursor.execute(statement, parameters)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     result = self._query(query)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     conn.query(q)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     self._affected_rows = self._read_query_result(unbuffered=unbuffered)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     result.read()
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 1082, in read
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     self._read_result_packet(first_packet)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 1152, in _read_result_packet
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     self._read_rowdata_packet()
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 1186, in _read_rowdata_packet
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     packet = self.connection._read_packet()
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     packet.check_error()
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     err.raise_mysql_exception(self._data)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     raise errorclass(errno, errval)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager pymysql.err.InternalError: (1205, 'Lock wait timeout exceeded; try restarting transaction')
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager The above exception was the direct cause of the following exception:
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager Traceback (most recent call last):
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/Workspace/ussuri/networking-aci/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py", line 48, in __init__
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     self._sync_allocations()
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/Workspace/ussuri/networking-aci/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py", line 360, in _sync_allocations
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     for alloc in allocs:
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 3405, in __iter__
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     return self._execute_and_instances(context)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/orm/query.py", line 3430, in _execute_and_instances
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     result = conn.execute(querycontext.statement, self._params)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 984, in execute
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     return meth(self, multiparams, params)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/sql/elements.py", line 293, in _execute_on_connection
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     return connection._execute_clauseelement(self, multiparams, params)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1103, in _execute_clauseelement
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     distilled_params,
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1288, in _execute_context
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     e, statement, parameters, cursor, context
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1479, in _handle_dbapi_exception
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     util.raise_(newraise, with_traceback=exc_info[2], from_=e)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 178, in raise_
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     raise exception
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/engine/base.py", line 1248, in _execute_context
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     cursor, statement, parameters, context
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/sqlalchemy/engine/default.py", line 590, in do_execute
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     cursor.execute(statement, parameters)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     result = self._query(query)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     conn.query(q)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     self._affected_rows = self._read_query_result(unbuffered=unbuffered)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     result.read()
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 1082, in read
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     self._read_result_packet(first_packet)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 1152, in _read_result_packet
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     self._read_rowdata_packet()
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 1186, in _read_rowdata_packet
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     packet = self.connection._read_packet()
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     packet.check_error()
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     err.raise_mysql_exception(self._data)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager   File "/Users/d072895/.virtualenvs/ussuri_python3.6/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager     raise errorclass(errno, errval)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager oslo_db.exception.DBDeadlock: (pymysql.err.InternalError) (1205, 'Lock wait timeout exceeded; try restarting transaction')
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager [SQL: SELECT aci_port_binding_allocations.host AS aci_port_binding_allocations_host, aci_port_binding_allocations.level AS aci_port_binding_allocations_level, aci_port_binding_allocations.segment_type AS aci_port_binding_allocations_segment_type, aci_port_binding_allocations.segmentation_id AS aci_port_binding_allocations_segmentation_id, aci_port_binding_allocations.segment_id AS aci_port_binding_allocations_segment_id, aci_port_binding_allocations.network_id AS aci_port_binding_allocations_network_id
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager FROM aci_port_binding_allocations FOR UPDATE]
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager (Background on this error at: http://sqlalche.me/e/2j85)
2021-08-24 17:18:15,854.854 10206 ERROR networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager
2021-08-24 17:18:15,866.866 10206 CRITICAL neutron.plugins.ml2.managers [req-411b4fab-9e38-404a-908d-47825319a2a7 gNone - - - - -] The 'aci = networking_aci.plugins.ml2.drivers.mech_aci.driver:CiscoACIMechanismDriver' entrypoint could not be loaded for the following reason: '(pymysql.err.InternalError) (1205, 'Lock wait timeout exceeded; try restarting transaction')
[SQL: SELECT aci_port_binding_allocations.host AS aci_port_binding_allocations_host, aci_port_binding_allocations.level AS aci_port_binding_allocations_level, aci_port_binding_allocations.segment_type AS aci_port_binding_allocations_segment_type, aci_port_binding_allocations.segmentation_id AS aci_port_binding_allocations_segmentation_id, aci_port_binding_allocations.segment_id AS aci_port_binding_allocations_segment_id, aci_port_binding_allocations.network_id AS aci_port_binding_allocations_network_id
FROM aci_port_binding_allocations FOR UPDATE]
(Background on this error at: http://sqlalche.me/e/2j85)'.: oslo_db.exception.DBDeadlock: (pymysql.err.InternalError) (1205, 'Lock wait timeout exceeded; try restarting transaction')
(pymysql.err.InternalError) (1205, 'Lock wait timeout exceeded; try restarting transaction')
[SQL: SELECT aci_port_binding_allocations.host AS aci_port_binding_allocations_host, aci_port_binding_allocations.level AS aci_port_binding_allocations_level, aci_port_binding_allocations.segment_type AS aci_port_binding_allocations_segment_type, aci_port_binding_allocations.segmentation_id AS aci_port_binding_allocations_segmentation_id, aci_port_binding_allocations.segment_id AS aci_port_binding_allocations_segment_id, aci_port_binding_allocations.network_id AS aci_port_binding_allocations_network_id
FROM aci_port_binding_allocations FOR UPDATE]
(Background on this error at: http://sqlalche.me/e/2j85)
```