### PR TITLE
Honor AZ hints in portbindings

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/config.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/config.py
@@ -108,6 +108,10 @@ aci_opts = [
                default=False,
                help="Port updates (e.g. binding host removed/changed) are only handled for trunk ports. "
                     "This can be enabled for all ports, but this might have unforseen sideeffects (untested)."),
+    cfg.StrOpt('az_checks_enabled',
+               default=True,
+               help="Enable AZ checks for port creation (default on). If AZ checks are disabled and the check fails "
+                    "port binding will not be blocked and a warning will be logged instead."),
 ]
 
 hostgroup_opts = [
@@ -123,6 +127,12 @@ hostgroup_opts = [
                help="Segment type, currently only vlan is supported"),
     cfg.ListOpt('segment_range', default=[],
                 help="Vlan/segment range to use, specified as from:to. Can have multiple entries separated by ','"),
+    cfg.ListOpt('availability_zones', default=[],
+                help='AZ this hostgroup is in. If a network has an AZ hint set then a port of this network can only '
+                     'be bound if the AZ from the hint is present in this list'),
+    cfg.DictOpt('host_azs', default={},
+                help="Specify an AZ for a bindinghost in the format of 'host:AZ,host:AZ,...'. "
+                     "This overrules the hostgroup's AZ"),
     cfg.BoolOpt('finalize_binding', default=False,
                 help="Finalize portbinding. The port will be bound directly to ACI, but without being in direct mode. "
                      "This can be used for dummy portbindings or where no other driver should be involved. The driver "

--- a/networking_aci/plugins/ml2/drivers/mech_aci/exceptions.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/exceptions.py
@@ -65,3 +65,12 @@ class HostAlreadyHasAccessBinding(exceptions.NeutronException):
 class AccessSegmentationIdAllocationPoolExhausted(exceptions.NeutronException):
     message = ("Cannot allocate segmentation id for %(hostgroup_name)s - "
                "the access segmentation id pool for physical network %(physical_network)s is exhausted")
+
+
+class OnlyOneAZHintAllowed(exceptions.BadRequest):
+    message = "Only one availability zone hint allowed per object"
+
+
+class HostgroupNetworkAZAffinityError(exceptions.BadRequest):
+    message = ("Hostgroup %(hostgroup_name)s with %(host)s resides in AZ %(hostgroup_az)s, network requires "
+               "AZ %(network_az)s; AZ mismatch for port %(port_id)s")


### PR DESCRIPTION
Add a (create|update)_port_precommit hook that checks if a port can be
bound to a certain hostgroup. Hostgroups need to be annotated with a
list of AZs they accept for this to work. A restriction of one AZ hint
per network is put on networks. AZ checks on portbind can be disabled
with the config option "az_checks_enabled".