### PR TITLE
Finalize bindings for hostgroups without a 2nd level

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/config.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/config.py
@@ -123,6 +123,10 @@ hostgroup_opts = [
                help="Segment type, currently only vlan is supported"),
     cfg.ListOpt('segment_range', default=[],
                 help="Vlan/segment range to use, specified as from:to. Can have multiple entries separated by ','"),
+    cfg.BoolOpt('finalize_binding', default=False,
+                help="Finalize portbinding. The port will be bound directly to ACI, but without being in direct mode. "
+                     "This can be used for dummy portbindings or where no other driver should be involved. The driver "
+                     "will still do a two level portbinding, where both levels are this driver."),
 
     # non-hierarchical portbinding / baremetal options
     cfg.BoolOpt('direct_mode', default=False,


### PR DESCRIPTION
This allows ports in a hostgroup to be directly bound on ACI without
having to deal with the ACI direct_mode. ACI direct mode is explicitly
thought out for server directly connected to ACI, but in some cases we
just need to make a vlan id available via a trunk, just like in normal
binding mode, but where no second level driver is available. "Finalize
bindings" allows us to do just that - finalize a binding directly on
ACI. These hostgroups will also not show up in the list-hostgroup-modes
API.