### PR TITLE
Fix PortBindingLevel join condition for multiple portbindings

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/common.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/common.py
@@ -23,6 +23,7 @@ from neutron.db import segments_db as ml2_db
 from neutron.plugins.ml2 import models as ml2_models
 import neutron.services.trunk.models as trunk_models
 from oslo_log import log as logging
+import sqlalchemy as sa
 
 from networking_aci.db.models import HostgroupModeModel
 from networking_aci.plugins.ml2.drivers.mech_aci import constants as aci_const
@@ -121,7 +122,8 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
             fields.append(ml2_models.PortBindingLevel.segment_id)
         query = context.session.query(*fields)
         query = query.join(ml2_models.PortBindingLevel,
-                           ml2_models.PortBinding.port_id == ml2_models.PortBindingLevel.port_id)
+                           sa.and_(ml2_models.PortBinding.port_id == ml2_models.PortBindingLevel.port_id,
+                                   ml2_models.PortBinding.host == ml2_models.PortBindingLevel.host))
         query = query.join(segment_models.NetworkSegment,
                            ml2_models.PortBindingLevel.segment_id == segment_models.NetworkSegment.id)
         query = query.filter(segment_models.NetworkSegment.network_id == network_id)


### PR DESCRIPTION
We try to find out which binding hosts are on a network by asking the
DB, specifically the models PortBinding/PortBindingLevels. For migration
purposes a portbinding might have two portbindings at the same time,
meaning it has two entries in the PortBinding's table. Each entry has
its own "host", but in our get_hosts_on_network() method, we only did the
join between PortBinding/PortBindingLevel by port_id, not by port_id AND
host. This resulted  in the wrong binding/segment getting mapped to the
wrong host. Now we join on both fields and have no longer alternating results
for this join.

The whole bug resulted in some bindings being deleted and readded to an
EPG that had one of these ports in it, essentially flapping the binding
around and adding a wrong vlan into the EPG. This should now be fixed.