### PR TITLE
Fix cobra import for l3ext for ext subnet sync

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 from cobra.model import fv, fvns, infra, phys
-from cobra import modelimpl
+import cobra.modelimpl.l3ext.out
 import netaddr
 from neutron_lib import context
 from oslo_config import cfg
@@ -562,7 +562,7 @@ class CobraManager(object):
 
         l3_out = self.apic.lookupByDn("uni/tn-{}/out-{}".format(tenant_name, out_name))
 
-        if isinstance(l3_out, modelimpl.l3ext.out.Out):
+        if isinstance(l3_out, cobra.modelimpl.l3ext.out.Out):
             return l3_out
 
         return None

--- a/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/agent/test_aci_agent.py
+++ b/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/agent/test_aci_agent.py
@@ -34,6 +34,7 @@ class AciNeutronAgentTest(base.BaseTestCase):
         sys.modules['cobra.mit.request'] = mock.MagicMock()
         sys.modules['cobra.model'] = mock.MagicMock()
         sys.modules['cobra.model.fv'] = mock.MagicMock()
+        sys.modules['cobra.modelimpl.l3ext.out'] = mock.MagicMock()
         from networking_aci.plugins.ml2.drivers.mech_aci.agent.aci_agent import AciNeutronAgent
 
         self.aci_agent = AciNeutronAgent()


### PR DESCRIPTION
External subnets cannot be properly synced, as this runs into an
exception in _find_l3_out():

AttributeError: module 'cobra.modelimpl' has no attribute 'l3ext'

This probably happened when we moved from acicobra3 to acicobra4 (or we
never had broken external subnets in a syncloop). To fix this and have
l3ext available we now directly import it.