### PR TITLE
Fix "No mos in config request" CommitError in agent

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
@@ -200,7 +200,12 @@ class CobraManager(object):
                 port.delete()
             entities.append(port)
 
-        self.apic.commit(entities)
+        if entities:
+            self.apic.commit(entities)
+        else:
+            binding_hosts = ", ".join(host_config['hosts']) if host_config else "<no hosts>"
+            LOG.debug("Sync of network %s for binding hosts '%s' did not have any bindings, skipping this hostgroup",
+                      network_id, binding_hosts)
 
         # Associate to Physical Domain
         for physdom in host_config['physical_domain']:


### PR DESCRIPTION
In certain circumstances _get_network() could provide an entry that
contains a config without bindings in it. This can happen when all
bindings of a non-direct-mode hostgroup are used in the same network in
direct-mode. As we cannot mix tagged and untagged bindings inside an EPG
the untagged bindings take precedence. If we remove all bindings of a
hostgroup the agent does not want to commit this (why should it, there
is nothing to commit). ACI raises a config error here. To prevent that
we now only do a commit for the bindings once we actually have something
to commit.