### PR TITLE
Small fix in exception message for afinity error

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
@@ -331,7 +331,7 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
             hg_az = [hostgroup['host_azs'][host]] if host in hostgroup['host_azs'] else hostgroup['availability_zones']
             if len(hg_az) > 1 or az_hint != hg_az[0]:
                 exc = aci_exc.HostgroupNetworkAZAffinityError(port_id=port['id'], hostgroup_name=hostgroup_name,
-                                                              host=host, hostgroup_az=hg_az,
+                                                              host=host, hostgroup_az=", ".join(hg_az),
                                                               network_az=az_hint)
                 if CONF.ml2_aci.az_checks_enabled:
                     raise exc


### PR DESCRIPTION
hg_az is a list and it looks ugly in the logged exceptions/error
messages and also when reported to the user. Doing a join() on the list
looks much nicer.