### PR TITLE
Python 3.8: github workflow and tox, call register_options in test_aci_agent

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -2,14 +2,14 @@ name: run-tox
 on:
   push:
     branches:
-      - stable/ussuri-m3
+      - stable/yoga-m3
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6]
+        python: [3.8]
     steps:
       - uses: actions/checkout@v2
       - name: Setup python
@@ -17,6 +17,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox
-        run: pip install tox
+        run: pip install "tox<4.0"
       - name: Run Tox
         run: "tox -e py"

--- a/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/agent/test_aci_agent.py
+++ b/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/agent/test_aci_agent.py
@@ -35,7 +35,10 @@ class AciNeutronAgentTest(base.BaseTestCase):
         sys.modules['cobra.model'] = mock.MagicMock()
         sys.modules['cobra.model.fv'] = mock.MagicMock()
         sys.modules['cobra.modelimpl.l3ext.out'] = mock.MagicMock()
+
+        from networking_aci.plugins.ml2.drivers.mech_aci.agent.entry_point import register_options
         from networking_aci.plugins.ml2.drivers.mech_aci.agent.aci_agent import AciNeutronAgent
+        register_options()
 
         self.aci_agent = AciNeutronAgent()
         self.aci_agent.agent_rpc = mock.MagicMock()

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,12 +16,9 @@ classifier =
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 2.6
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
-    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 keywords = openstack neutron ACI networking
 
 [files]

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,19 @@
 [tox]
-envlist = py27,py36
+envlist = py38
 minversion = 3.2
 skipsdist = True
 requires = virtualenv >= 20
 
 [testenv]
 usedevelop = True
-install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/ussuri-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
+install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
 # pip 20.2.3 is used until constraints as urls are reintroduced in pip
 # see https://github.com/pypa/pip/issues/8253 or PR 9673 (currently merged, not released)
 setenv = VIRTUAL_ENV={envdir}
          VIRTUALENV_PIP=20.2.3
          PYTHONWARNINGS=default::DeprecationWarning
 deps = -r{toxinidir}/test-requirements.txt
-       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/ussuri-m3#egg=neutron}
+       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/yoga-m3#egg=neutron}
 whitelist_externals = sh
 commands = python setup.py testr --slowest --testr-args='{posargs}'
 download = True


### PR DESCRIPTION
Use tox version <4.0 in github actions, run actions on stable/yoga-m3 and run tox test with python version 3.8
Before test_aci_agent executes, properly register all options required by the agent as done during the normal agent start.