### PR TITLE
Disable dynamic segment filter

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/common.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/common.py
@@ -254,7 +254,7 @@ class DBPlugin(db_base_plugin_v2.NeutronDbPluginV2,
 
 
 def get_segments(context, network_id):
-    return ml2_db.get_network_segments(context, network_id)
+    return ml2_db.get_network_segments(context, network_id, filter_dynamic=None)
 
 
 def get_switch_from_local_link(binding_profile):


### PR DESCRIPTION
We have some segments that are created with the dynamic flag and some that are not. In ussuri the dynamic segment filter was disabled by default (set to None), but now the default is False (no dynamic segments). To get back the old behavior we now explicitly set it to None.