### PR TITLE
Fix trunk RPC handlers

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/trunk.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/trunk.py
@@ -77,7 +77,7 @@ class ACITrunkDriver(base.DriverBase):
         elif resource == resources.SUBPORTS:
             # Subports resource contains states
             # Event: https://github.com/sapcc/neutron/blob/e49485f2aa7dd48f57f2d94080a37c49306e87d4/neutron/services/trunk/plugin.py#L362
-            current_state == payload.states[0]
+            current_state = payload.states[0]
         else:
             raise NeutronException("Unsupported type of resource {}".format(resource))
         ctx, parent = self._get_context_and_parent_port(current_state.port_id)

--- a/networking_aci/plugins/ml2/drivers/mech_aci/trunk.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/trunk.py
@@ -131,7 +131,7 @@ class ACITrunkDriver(base.DriverBase):
             return
 
         LOG.info("Trunk create called, resource %s payload %s trunk id %s",
-                 resource, payload, payload.trunk_id)
+                 resource, payload, payload.resource_id)
         self._bind_subports(ctx, parent, payload.states[0], payload.states[0].sub_ports)
         payload.states[0].update(status=trunk_const.TRUNK_ACTIVE_STATUS)
 
@@ -140,7 +140,7 @@ class ACITrunkDriver(base.DriverBase):
         if not parent:
             return
 
-        LOG.info("Trunk %s delete called", payload.trunk_id)
+        LOG.info("Trunk %s delete called", payload.resource_id)
         self._bind_subports(ctx, parent, payload.states[0], payload.states[0].sub_ports, delete=True)
 
     def subport_create(self, resource, event, trunk_plugin, payload):


### PR DESCRIPTION
In these two commits:
https://github.com/sapcc/neutron/commit/129b823a8b610284ff95cc5e7b2f7b6ed3540172
https://github.com/sapcc/neutron/commit/69ef824069c3b1435a50c0d937ad45a23ff07c1b
the RPC was changed to use DBEventPayload from the neutron library instead of custom objects.

The new payload has different formats for different event types, here documentation: https://docs.openstack.org/neutron-lib/latest/contributor/callbacks.html#event-objects-dbeventpayload

In this PR we change our driver to have the correct handlers for RPC events coming from Neutron server. 