### PR TITLE
Don't log an error on "invalid" binding profile

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/common.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/common.py
@@ -277,7 +277,7 @@ def get_switch_from_local_link(binding_profile):
                 LOG.error("Cannot determine switch for local link info %s in binding profile %s.",
                           lli[0], binding_profile)
         else:
-            LOG.error("Local information %s is invalid in binding profile %s.",
+            LOG.debug("Local information %s contains no binding host / switch info in profile %s, ignoring it",
                       lli, binding_profile)
 
 


### PR DESCRIPTION
We used to log an error if the binding profile didn't contain a binding host (as we have it for ports created by ironic) but nowadays the binding profile is used for many more cases and doesn't always contain a host. Also, we never needed to act on a "broken" binding profile. If we would need to do that there are many other means to find it. Therefore we lower the log level from error to debug.