### PR TITLE
Do not configure hostgroup mode if port-selectors are missing

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
@@ -270,6 +270,10 @@ class CobraManager(object):
         self.apic.commit([aep, physdom, vlan_pool, pc_profile])
 
     def ensure_hostgroup_mode_config(self, host_config, source=""):
+        if not host_config.get('port_selectors'):
+            LOG.info("No port selectors configured for hostgroup %s %s, skipping hostgroup mode configuration",
+                     host_config['name'], source)
+            return
         if host_config['hostgroup_mode'] == aci_const.MODE_BAREMETAL:
             if not self.ensure_baremetal_entities(host_config['pc_policy_group'],
                                                   host_config['baremetal_resource_name'],
@@ -282,6 +286,7 @@ class CobraManager(object):
             LOG.error("No port selector entity configuration could be generated for hostgroup %s %s"
                       " - are there configuration entities missing?",
                       host_config['name'], source)
+            return
         self.apic.commit(port_sel_entities)
 
     def create_subnet(self, subnet, external, address_scope_name, network_az):


### PR DESCRIPTION
Port-selectors are only needed if we disassemble the port-selector
pc-policy relationship when we come and go from baremetal mode. If a
host is not planned to ever go into baremetal that relationship is
already formed and will never be destroyed, we can thus bypass that
code.

Also adding a return if `port_sel_entities` is empty so we do not throw
an empty list to the API.
