### PR TITLE
Properly delete unwanted subnet on network sync

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
@@ -606,6 +606,10 @@ class CobraManager(object):
 
     def clean_subnets(self, network):
         network_id = network['id']
+        network_az = None
+        if network.get(az_def.AZ_HINTS):
+            network_az = network[az_def.AZ_HINTS][0]
+
         bd = self.get_bd(network_id)
         if bd:
             neutron_subnets = []
@@ -616,7 +620,8 @@ class CobraManager(object):
             for subnet in bd.subnet:
                 if subnet.ip not in neutron_subnets:
                     LOG.warning("Cleaning subnet %s on BD %s", subnet.ip, network_id)
-                    self.ensure_subnet_deleted(network_id, subnet.ip)
+                    self.ensure_subnet_deleted(network_id, neutron_subnet.get('address_scope_name'), subnet.ip,
+                                               network_az)
 
     def clean_physdoms(self, network):
         network_id = network['id']


### PR DESCRIPTION
When syncing a network we are cleaning a BD as well. If the BD has extra subnets we call ensure_subnet_deleted(). Somehow we missed to pass the address scope name and the network az along to this call when we did the core 2.1 refactoring, resulting in a TypeError here.