### PR TITLE
Fix login URL for ACI 5.x compatibility

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
@@ -103,7 +103,7 @@ class CobraClient(object):
         LOG.info(hosts)
 
         protocol = 'https' if ssl else 'http'
-        self.api_base = collections.deque(['%s://%s/api' % (protocol, host) for host in hosts])
+        self.api_base = collections.deque(['%s://%s' % (protocol, host) for host in hosts])
         self.verify = verify
         self.timeout = 90
         self.user = user


### PR DESCRIPTION
The /api suffix for the login URL is not needed and breaks with ACI 5.x. Luckily we can just omit it and it seems to be working again. As our internal debug toolkit has also a "special" acicobra abstraction which also doesn't include the /api suffix, we have already tested this working in some of our production regions, which are still on an older verison of ACI.