### PR TITLE
Ensure subnet-network AZ and subnetpool AZ match

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/config.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/config.py
@@ -124,6 +124,9 @@ aci_opts = [
                 help="Enable nullroute sync"),
     cfg.BoolOpt('enable_az_aware_subnet_routes_sync', default=True,
                 help="Enable AZ aware subnet routes sync"),
+    cfg.BoolOpt("subnet_subnetpool_az_check_enabled", default=True,
+                help="Check if a subnet's network az hint matches the subnetpool's az hint (tag) on "
+                     "creation of an external subnet"),
 ]
 
 hostgroup_opts = [

--- a/networking_aci/plugins/ml2/drivers/mech_aci/constants.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/constants.py
@@ -26,4 +26,6 @@ TRUNK_PROFILE = 'aci_trunk'
 CC_FABRIC_TRANSIT = 'cc-fabric-transit'  # needs to be aligned with networking-ccloud
 CC_FABRIC_NET_GW = 'cc-fabric-network-gateway'
 
+AZ_TAG_PREFIX = 'availability-zone::'
+
 CC_FABRIC_L3_GATEWAY_TAG = 'gateway-host::cc-fabric'

--- a/networking_aci/plugins/ml2/drivers/mech_aci/exceptions.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/exceptions.py
@@ -79,3 +79,8 @@ class HostgroupNetworkAZAffinityError(exceptions.BadRequest):
 class TransitBindingProhibited(exceptions.BadRequest):
     """Raised when a user tries to bind a transit"""
     message = ("Binding transit hostgroups is prohibited (port %(port_id)s host %(host)s")
+
+
+class SubnetSubnetPoolAZAffinityError(exceptions.BadRequest):
+    message = ("The subnet's network %(network_id)s has AZ hint %(net_az_hint)s, "
+               "the subnet's subnetpool %(subnetpool_id)s has AZ %(subnetpool_az)s set, which do not match")

--- a/networking_aci/tests/base.py
+++ b/networking_aci/tests/base.py
@@ -1,0 +1,19 @@
+from neutron.common import config
+from neutron.tests.unit.plugins.ml2 import test_plugin
+from oslo_config import cfg
+from oslotest import base
+
+from networking_aci.plugins.ml2.drivers.mech_aci import constants
+
+
+class NetworkingAciMechanismDriverTestBase(test_plugin.Ml2PluginV2TestCase, base.BaseTestCase):
+    """Test case base class for all unit tests."""
+
+    def get_additional_service_plugins(self):
+        return dict(service_plugins='tag')
+
+    def setUp(self):
+        self._mechanism_drivers.append(constants.ACI_DRIVER_NAME)
+        cfg.CONF.set_override('debug', True)
+        config.setup_logging()
+        super().setUp()

--- a/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/test_driver.py
+++ b/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/test_driver.py
@@ -1,0 +1,81 @@
+import re
+
+from neutron.db.models import address_scope as ascope_models
+from neutron.db.models import tag as tag_models
+from neutron.db import models_v2
+from neutron_lib.api.definitions import external_net as extnet_api
+from neutron_lib import context
+from neutron.tests.common import helpers as neutron_test_helpers
+from neutron.tests.unit.plugins.ml2 import test_plugin
+from oslo_config import cfg
+
+from networking_aci.tests import base
+
+
+class NetworkingAciMechanismDriverSubnetPoolTest(base.NetworkingAciMechanismDriverTestBase):
+
+    def _register_azs(self):
+        self.agent1 = neutron_test_helpers.register_dhcp_agent(host='network-agent-a-1', az='qa-de-1a')
+        self.agent2 = neutron_test_helpers.register_dhcp_agent(host='network-agent-b-1', az='qa-de-1b')
+        self.agent3 = neutron_test_helpers.register_dhcp_agent(host='network-agent-c-1', az='qa-de-1c')
+
+    def setUp(self):
+        super().setUp()
+        self._register_azs()
+        ctx = context.get_admin_context()
+        with ctx.session.begin(subtransactions=True):
+            self._address_scope = ascope_models.AddressScope(name="the-open-sea", ip_version=4)
+            ctx.session.add(self._address_scope)
+
+    def test_create_subnet_az_hint_matches(self):
+        net_kwargs = {'arg_list': (extnet_api.EXTERNAL,), extnet_api.EXTERNAL: True}
+        with self.network(**net_kwargs) as network:
+            with self.subnetpool(["1.1.0.0/16", "1.2.0.0/24"], name="foo", tenant_id="foo", admin=True) as snp:
+                with self.subnet(network=network, cidr="1.1.1.0/24", gateway_ip="1.1.1.1",
+                                 subnetpool_id=snp['subnetpool']['id']) as subnet:
+                    self.assertIsNotNone(subnet)
+
+    def test_create_subnet_network_az_snp_no_az_fails(self):
+        net_kwargs = {'arg_list': (extnet_api.EXTERNAL,), extnet_api.EXTERNAL: True}
+        with self.network(availability_zone_hints=["qa-de-1a"], **net_kwargs) as network:
+            with self.subnetpool(["1.1.0.0/16", "1.2.0.0/24"], address_scope_id=self._address_scope['id'], name="foo",
+                                 tenant_id="foo", admin=True) as snp:
+                resp = self._create_subnet(self.fmt, cidr="1.1.1.0/24", gateway_ip="1.1.1.1",
+                                           name="foo",
+                                           net_id=network['network']['id'], tenant_id=network['network']['tenant_id'],
+                                           subnetpool_id=snp['subnetpool']['id'])
+                self.assertEqual(400, resp.status_code)
+                self.assertEqual("SubnetSubnetPoolAZAffinityError", resp.json['NeutronError']['type'])
+                self.assertIsNotNone(re.search(f"network {network['network']['id']} has AZ hint qa-de-1a,.*"
+                                               f"{snp['subnetpool']['id']} has AZ None set, which do not match",
+                                               resp.json['NeutronError']['message']))
+
+    def test_create_subnet_network_no_az_snp_az_fails(self):
+        net_kwargs = {'arg_list': (extnet_api.EXTERNAL,), extnet_api.EXTERNAL: True}
+        with self.network(**net_kwargs) as network:
+            with self.subnetpool(["1.1.0.0/16", "1.2.0.0/24"], address_scope_id=self._address_scope['id'], name="foo",
+                                 tenant_id="foo", admin=True) as snp:
+                ctx = context.get_admin_context()
+                with ctx.session.begin():
+                    snp_db = ctx.session.query(models_v2.SubnetPool).get(snp['subnetpool']['id'])
+                    ctx.session.add(tag_models.Tag(standard_attr_id=snp_db.standard_attr_id,
+                                    tag="availability-zone::qa-de-1a"))
+                resp = self._create_subnet(self.fmt, cidr="1.1.1.0/24", gateway_ip="1.1.1.1",
+                                           name="foo",
+                                           net_id=network['network']['id'], tenant_id=network['network']['tenant_id'],
+                                           subnetpool_id=snp['subnetpool']['id'])
+                self.assertEqual(400, resp.status_code)
+                self.assertEqual("SubnetSubnetPoolAZAffinityError", resp.json['NeutronError']['type'])
+                self.assertIsNotNone(re.search(f"network {network['network']['id']} has AZ hint None,.*"
+                                               f"{snp['subnetpool']['id']} has AZ qa-de-1a set, which do not match",
+                                               resp.json['NeutronError']['message']))
+
+    def test_create_subnet_network_snp_az_hint_works_when_turned_off(self):
+        cfg.CONF.set_override('subnet_subnetpool_az_check_enabled', False, group='ml2_aci')
+        net_kwargs = {'arg_list': (extnet_api.EXTERNAL,), extnet_api.EXTERNAL: True}
+        with self.network(availability_zone_hints=["qa-de-1a"], **net_kwargs) as network:
+            with self.subnetpool(["1.1.0.0/16", "1.2.0.0/24"], address_scope_id=self._address_scope['id'], name="foo",
+                                 tenant_id="foo", admin=True) as snp:
+                with self.subnet(network=network, cidr="1.1.1.0/24", gateway_ip="1.1.1.1",
+                                 subnetpool_id=snp['subnetpool']['id']) as subnet:
+                    self.assertIsNotNone(subnet)


### PR DESCRIPTION
Backported from https://github.com/sapcc/networking-ccloud/commit/870fa5f6b31748435523b45aec39a6171f99af1e

When a new subnet is created in an external network we now check that
the subnet's network's AZ hint matches the AZ of the subnetpool (given
to the subnetpool by a tag). This check is only executed if the
subnetpool has an address scope, because a) we only need to enforce this
for networks that are also "present in a VRF", which is managed via
address scopes (else the subnet is really more of an internal flavor...)
and b) because it was a bit more convenient to implement for me (which
means that we can definitely change this implementation if we need to).

The config option subnet_subnetpool_az_check_enabled is added so we can
turn this feature off if it ever breaks something in prod and we quickly
need to disable it without doing a drive code change. I don't really
expect us needing it, but you never know.
