### PR TITLE
Fix allocation cleaning deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .tox/
 networking_aci.egg-info/
 .testrepository/
+.stestr/

--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,0 +1,3 @@
+[DEFAULT]
+test_path=${OS_TEST_PATH:-./networking_aci/tests/unit}
+top_dir=./

--- a/.testr.conf
+++ b/.testr.conf
@@ -1,8 +1,0 @@
-[DEFAULT]
-test_command=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
-             OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} \
-             OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-60} \
-             OS_LOG_CAPTURE=1 \
-             ${PYTHON:-python} -m subunit.run discover -t ./ . $LISTOPT $IDOPTION
-test_id_option=--load-list $IDFILE
-test_list_option=--list

--- a/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
@@ -12,6 +12,7 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import os
 import random
 import time
 
@@ -19,6 +20,7 @@ from neutron_lib import context
 from neutron_lib.db import api as db_api
 from neutron.db.models import segment as ml2_models
 from neutron.plugins.ml2 import models
+from oslo_concurrency import lockutils
 from oslo_config import cfg
 from oslo_db import exception as db_exc
 from oslo_log import log
@@ -43,7 +45,30 @@ CONF = cfg.CONF
 class AllocationsManager(object):
     def __init__(self, db):
         self.db = db
+        self._sync_db_guarded()
 
+    def initialize(self):
+        self._sync_db_guarded()
+        LOG.info(_LI("AllocationsManager initialization complete"))
+
+    def _sync_db_guarded(self):
+        if not CONF.ml2_aci.sync_allocations_done_file_path:
+            # sync db unconditionally
+            self._sync_db()
+            return
+
+        # first process/thread gathering the lock syncs the table
+        with lockutils.external_lock("sync-allocations-guard", lock_file_prefix="networking-aci"):
+            try:
+                synced_by = open(CONF.ml2_aci.sync_allocations_done_file_path, "r").read()
+                LOG.info("Not syncing in this thread, already synced by PID %s", synced_by)
+            except FileNotFoundError:
+                self._sync_db()
+                with open(CONF.ml2_aci.sync_allocations_done_file_path, "w") as f:
+                    f.write(str(os.getpid()))
+                LOG.info("Successfully synced db")
+
+    def _sync_db(self):
         if CONF.ml2_aci.sync_allocations:
             try:
                 self._sync_allocations()
@@ -51,15 +76,6 @@ class AllocationsManager(object):
                 LOG.exception("__init__ sync alloc")
                 raise
         self._sync_hostgroup_modes()
-
-    def initialize(self):
-        try:
-            self._sync_allocations()
-        except Exception:
-            LOG.exception("initialize sync alloc")
-            raise
-        self._sync_hostgroup_modes()
-        LOG.info(_LI("AllocationsManager initialization complete"))
 
     def network_type_not_supported(self, network, host_id, level, segment_type, segment_physnet):
         LOG.error("Network type " + network["provider:network_type"] + " is not supported in the ACI driver")

--- a/networking_aci/plugins/ml2/drivers/mech_aci/config.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/config.py
@@ -81,6 +81,8 @@ aci_opts = [
     cfg.BoolOpt('sync_allocations',
                 default=True,
                 help="Sync allocations on startup"),
+    cfg.StrOpt('sync_allocations_done_file_path',
+               help="File to touch once one process on the system has synced the allocations table"),
     cfg.StrOpt('ep_retention_policy_net_internal',
                default=None,
                help="Name of the endpoint retention policy to use for internal networks. "

--- a/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/test_allocations_manager.py
+++ b/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/test_allocations_manager.py
@@ -1,0 +1,103 @@
+# Copyright 2024 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from unittest import mock
+
+from neutron_lib import context
+from neutron_lib.db import api as db_api
+
+from neutron.tests.unit.db.test_db_base_plugin_v2 import NeutronDbPluginV2TestCase
+
+
+from networking_aci.db.models import AllocationsModel
+from networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager import AllocationsManager
+from networking_aci.plugins.ml2.drivers.mech_aci import common
+from networking_aci.plugins.ml2.drivers.mech_aci.config import ACI_CONFIG
+
+
+class TestAllocationsManager(NeutronDbPluginV2TestCase):
+    def test_sync_allocations(self):
+        ctx = context.get_admin_context()
+        net1 = self._make_network("json", "net1", True)['network']
+        net2 = self._make_network("json", "net2", True)['network']
+        net3 = self._make_network("json", "net3", True)['network']
+
+        start_data = [
+            ('seagull', 42, None),  # keep
+            ('seagull', 43, net1['id']),  # keep
+            ('seagull', 2323, None),  # delete (out of range)
+            ('seagull', 2324, net2['id']),  # keep (out of range, has network)
+            ('crow', 2323, None),  # delete (unknown hg)
+            ('crow', 2324, net3['id']),  # keep (unknown hg, has network)
+        ]
+
+        expected_result = [
+            ('crow', 2324, net3['id']),
+            ('oystercatcher', 100, None),
+            ('oystercatcher', 101, None),
+            ('oystercatcher', 102, None),
+            ('oystercatcher', 103, None),
+            ('seagull', 42, None),
+            ('seagull', 43, net1['id']),
+            ('seagull', 44, None),
+            ('seagull', 45, None),
+            ('seagull', 2324, net2['id']),
+
+            ('sentinel_1', 1, None),
+            ('sentinel_2', 2, None),
+        ]
+
+        with db_api.CONTEXT_WRITER.using(ctx) as sess:
+            for host, seg_id, net_id in start_data:
+                sess.add(AllocationsModel(host=host, level=1, segment_type="vlan", segmentation_id=seg_id,
+                                          network_id=net_id))
+
+            # wrong level, should not be touched
+            sess.add(AllocationsModel(host="sentinel_1", level=2, segment_type="vlan", segmentation_id=1))
+
+            # wrong segment_type, should not be touched
+            sess.add(AllocationsModel(host="sentinel_2", level=1, segment_type="foo", segmentation_id=2))
+
+        db = common.DBPlugin()
+        ACI_CONFIG.db = db
+
+        hostgroups = {
+            'seagull': {
+                'direct_mode': False,
+                'hosts': [],
+                'segment_range': [(42, 45)],
+                'segment_type': 'vlan',
+            },
+            'oystercatcher': {
+                'direct_mode': False,
+                'hosts': [],
+                'segment_range': [(100, 103)],
+                'segment_type': 'vlan',
+            },
+            'sparrow': {
+                'direct_mode': True,
+                'hosts': [],
+                'segment_range': [(123, 234)],
+                'segment_type': 'vlan',
+            },
+        }
+
+        with mock.patch('networking_aci.plugins.ml2.drivers.mech_aci.config.ACIConfig.hostgroups',
+                        new_callable=mock.PropertyMock, return_value=hostgroups):
+            AllocationsManager(db)
+
+        with db_api.CONTEXT_READER.using(ctx) as sess:
+            db_result = [(a.host, a.segmentation_id, a.network_id) for a in sess.query(AllocationsModel).all()]
+
+        self.assertEqual(sorted(expected_result), sorted(db_result))

--- a/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/test_allocations_manager.py
+++ b/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/test_allocations_manager.py
@@ -12,13 +12,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import os
+from pathlib import Path
+import tempfile
 from unittest import mock
 
 from neutron_lib import context
 from neutron_lib.db import api as db_api
-
 from neutron.tests.unit.db.test_db_base_plugin_v2 import NeutronDbPluginV2TestCase
-
+from oslo_config import cfg
 
 from networking_aci.db.models import AllocationsModel
 from networking_aci.plugins.ml2.drivers.mech_aci.allocations_manager import AllocationsManager
@@ -101,3 +103,31 @@ class TestAllocationsManager(NeutronDbPluginV2TestCase):
             db_result = [(a.host, a.segmentation_id, a.network_id) for a in sess.query(AllocationsModel).all()]
 
         self.assertEqual(sorted(expected_result), sorted(db_result))
+
+    def test_sync_allocations_locking(self):
+        db = common.DBPlugin()
+
+        with mock.patch.object(AllocationsManager, '_sync_db') as sync_db_mock:
+            AllocationsManager(db)
+            sync_db_mock.assert_called_once()
+            sync_db_mock.reset_mock()
+
+            # repeated calls get repeated syncs
+            AllocationsManager(db)
+            sync_db_mock.assert_called_once()
+            sync_db_mock.reset_mock()
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                sync_file = Path(tmpdir) / 'sync-done-file'
+                cfg.CONF.set_override('sync_allocations_done_file_path', str(sync_file), group='ml2_aci')
+
+                # sync, this time the file gets created
+                AllocationsManager(db)
+                sync_db_mock.assert_called_once()
+                sync_db_mock.reset_mock()
+
+                # sync not executed
+                AllocationsManager(db)
+                sync_db_mock.assert_not_called()
+
+                self.assertEqual(open(sync_file).read(), str(os.getpid()))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,8 +9,8 @@ coverage>=3.6
 python-subunit>=0.0.18
 oslosphinx!=3.4.0,>=2.5.0
 oslotest>=1.10.0
-testrepository>=0.0.18
 testscenarios>=0.4
 testtools>=1.4.0
 testresources>=0.2.4
 requests
+stestr>=1.0.0 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,18 @@
 [tox]
 envlist = py38
-minversion = 3.2
+minversion = 3.18.0
 skipsdist = True
 requires = virtualenv >= 20
 
 [testenv]
 usedevelop = True
 install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/yoga-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
-# pip 20.2.3 is used until constraints as urls are reintroduced in pip
-# see https://github.com/pypa/pip/issues/8253 or PR 9673 (currently merged, not released)
 setenv = VIRTUAL_ENV={envdir}
-         VIRTUALENV_PIP=20.2.3
          PYTHONWARNINGS=default::DeprecationWarning
 deps = -r{toxinidir}/test-requirements.txt
        -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/yoga-m3#egg=neutron}
 whitelist_externals = sh
-commands = python setup.py testr --slowest --testr-args='{posargs}'
+commands = stestr run {posargs}
 download = True
 
 [testenv:pep8]


### PR DESCRIPTION
The cleaning of unused allocations needs to be moved into the transaction to actually work.

We also improve the logging a bit by not logging each single allocation with two log lines and adding some debug logging to see how long each phase takes.

---
I looked into the sync code to improve the situation a bit and this was the most low hanging fruit I could find. Either reworking the logic or removing the sync loop altogether will still be in our future, though.