### PR TITLE
Allow disabling eventlet.monkey_patch() via envvar

### DIFF
--- a/networking_aci/__init__.py
+++ b/networking_aci/__init__.py
@@ -1,2 +1,5 @@
-import eventlet
-eventlet.monkey_patch()
+import os
+
+if not os.environ.get('DISABLE_EVENTLET_PATCHING'):
+    import eventlet
+    eventlet.monkey_patch()


### PR DESCRIPTION
To disable eventlet monkeypatching we can now set the environment variable DISABLE_EVENTLET_PATCHING to a value. This is done similarly in our asr1k driver.