### PR TITLE
allocation sync: use physnet, not hostgroup name

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/config.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/config.py
@@ -321,6 +321,8 @@ class ACIConfig:
         for hostgroup_name, hostgroup in self._hostgroups.items():
             hostgroup['name'] = hostgroup_name
             hostgroup['child_hostgroups'] = []
+            if 'physical_network' not in hostgroup:
+                hostgroup['physical_network'] = hostgroup_name
 
             # handle segment ranges
             segment_ranges = hostgroup['segment_range']


### PR DESCRIPTION
The allocation sync currently syncs the host allocations table by using the name of a hostgroup. This value is almost always the same as the physical network of the hostgroup, but not always. As new features will rely on multiple hostgroups belonging to the same physnet we need to fix this.

While doing so we also make sure that if we have multiple hostgroups for the same physnet, we merge the vlan ranges we find in the different hostgroups (that's what the new sorting and grouping is for).

In the config parser, we also now make sure the pyhsical_network config attribute is always set. For Converged Cloud, this is taken care of by the helm charts, but one can never be too sure (and this is not marked as a required attribute).