### PR TITLE
Fix AZ awareness check for subgroups

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/config.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/config.py
@@ -340,6 +340,10 @@ class ACIConfig:
                                                                         .format(far_hg, hostgroup_name))
                 self._hostgroups[far_hg]['child_hostgroups'].append(hostgroup_name)
 
+                # copy over AZs so the AZ check works properly for subgroups
+                if not hostgroup['availability_zones']:
+                    hostgroup['availability_zones'] = self._hostgroups[far_hg]['availability_zones']
+
             if not hostgroup['baremetal_pc_policy_group']:
                 hostgroup['baremetal_pc_policy_group'] = CONF.ml2_aci.default_baremetal_pc_policy_group
 

--- a/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
@@ -388,7 +388,7 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
         if az_hints:
             az_hint = az_hints[0]
             hg_az = [hostgroup['host_azs'][host]] if host in hostgroup['host_azs'] else hostgroup['availability_zones']
-            if len(hg_az) > 1 or az_hint != hg_az[0]:
+            if len(hg_az) != 1 or az_hint != hg_az[0]:
                 exc = aci_exc.HostgroupNetworkAZAffinityError(port_id=port['id'], hostgroup_name=hostgroup_name,
                                                               host=host, hostgroup_az=", ".join(hg_az),
                                                               network_az=az_hint)


### PR DESCRIPTION
Hostgroups with a parent group generally don't have an availability_zones attribute set, so they need to use the attribute from their parent group to properly work.

Also, we didn't properly handle hostgroups that do not have an availability_zones attribute set, so we now check for exactly one AZ instead of "more than one".