### PR TITLE
Fix L3 BD subnet cleaning

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
@@ -610,6 +610,13 @@ class CobraManager(object):
         if network.get(az_def.AZ_HINTS):
             network_az = network[az_def.AZ_HINTS][0]
 
+        # use first not-None address scope
+        address_scope = None
+        for subnet in network.get('subnets', []):
+            if subnet.get('address_scope_name'):
+                address_scope = subnet['address_scope_name']
+                break
+
         bd = self.get_bd(network_id)
         if bd:
             neutron_subnets = []
@@ -620,7 +627,7 @@ class CobraManager(object):
             for subnet in bd.subnet:
                 if subnet.ip not in neutron_subnets:
                     LOG.warning("Cleaning subnet %s on BD %s", subnet.ip, network_id)
-                    self.ensure_subnet_deleted(network_id, neutron_subnet.get('address_scope_name'), subnet.ip,
+                    self.ensure_subnet_deleted(network_id, address_scope, subnet.ip,
                                                network_az)
 
     def clean_physdoms(self, network):


### PR DESCRIPTION
When cleaning the L3 BD of an external subnet we need to make sure we pass along the correct address scope (again). The last fix only resulted in us using the address scope from the last iterated subnet in the code block over our block, but in cases where we don't have any subnets there (e.g. gateway was moved to another fabric) this would result in an UnboundLocalError for neutron_subnet. To fix this, we now iterate over all subnets and take the first not-None address scope to pass along. This should work, as in our infrastructure all subnets of a network must either have the same or no address scope.