### PR TITLE
Make sure internal networks get their VRF

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_manager.py
@@ -132,6 +132,11 @@ class CobraManager(object):
             epret = fv.RsBdToEpRet(bd, tnFvEpRetPolName=ep_retention_policy)
             bd_objs.append(epret)
 
+        if not external:
+            # make sure we have an RsCtx associated to the BD for internal networks, even if we don't have a subnet
+            rsctx = fv.RsCtx(bd, self.tenant_default_vrf, tnFvCtxName=self.tenant_default_vrf)
+            bd_objs.append(rsctx)
+
         # We have to make seperate config requests because cobra can't
         # handle MOs with different root contexts
         self.apic.commit(bd_objs)


### PR DESCRIPTION
For an internal network to work properly, it needs a VRF association, meaning we need a fvRsCtx associated to the BD. Before this commit, this was part of ensure_internal_network_configured(), which is called as a create_subnet_postcommit() hook. If that gets lost for any reason or maybe (I'm not sure of this) is faster than the original ensure_domain_and_epg() call, it might be the case that the RsCtx gets lost and the EPG is not usable with the following ACI fault:

Configuration failed for $epg_dn due to VRF Not Present,

To reduce the likelihood for internal networks, we now make sure to also create the fvRsCtx as part of ensure_domain_and_epg(). For external networks, we need subnets anyway and will keep it "the old way" of creating it as part of the create_subnet_postcommit() hook. If creating external subnets becomes a more regular operation and is indeed facing the same problem, we can revisit this decision.