### PR TITLE
Pass message argument to NeutronException

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
@@ -159,7 +159,7 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
                            .format(port['id'], hostgroup['name'], seg_port['port_id'], seg_port['project_id'],
                                    port['project_id']))
                     LOG.error(msg)
-                    raise n_exc.NeutronException(msg)
+                    raise n_exc.NeutronException(message=msg)
 
             ACI_CONFIG.annotate_baremetal_info(context._plugin_context, hostgroup, network['id'],
                                                override_project_id=port['project_id'])

--- a/networking_aci/plugins/ml2/drivers/mech_aci/trunk.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/trunk.py
@@ -77,7 +77,7 @@ class ACITrunkDriver(base.DriverBase):
             # Event: https://github.com/sapcc/neutron/blob/e49485f2aa7dd48f57f2d94080a37c49306e87d4/neutron/services/trunk/plugin.py#L362
             current_state = payload.states[0]
         else:
-            raise NeutronException("Unsupported type of resource {}".format(resource))
+            raise NeutronException(message="Unsupported type of resource {}".format(resource))
         parent = self._get_parent_port(payload.context, current_state.port_id)
         if not parent:
             return
@@ -87,7 +87,7 @@ class ACITrunkDriver(base.DriverBase):
 
         hostgroup_name, hostgroup = ACI_CONFIG.get_hostgroup_by_host(payload.context, parent_host)
         if not hostgroup:
-            raise NeutronException("No hostgroup config found for port {} host {}"
+            raise NeutronException(message="No hostgroup config found for port {} host {}"
                                    .format(current_state.port_id, parent_host))
 
         if not (hostgroup['direct_mode'] and hostgroup['hostgroup_mode'] == aci_const.MODE_BAREMETAL):


### PR DESCRIPTION
Passing a message as a positional argument to NeutronException does not work, we need to pass it as a keyword argument named message.