### PR TITLE
Recompute api token validity inside refresh lock

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/cobra_client.py
@@ -54,6 +54,12 @@ def _retry(func):
             if token_validity < CONF.ml2_aci.reauth_threshold:
                 LOG.debug("Acquiring session refresh lock")
                 with _TOKEN_REFRESH_LOCK:
+                    # refetch token validity in case another thread has refreshed the connection
+                    token_validity = (self.mo_dir.session.refreshTime or 0) - time.time()
+
+                    if self.mo_dir.session.refreshTime is None:
+                        LOG.warning("API mo_dir refreshTime was %s", self.mo_dir.session.refreshTime)
+
                     if token_validity >= CONF.ml2_aci.reauth_threshold:
                         LOG.debug("Session was already refreshed by another thread, continuing")
                     elif token_validity > 1:


### PR DESCRIPTION
When we check the token validity and acquire the token refresh lock we
need to make sure we compute the validity again, as it might have
changed due to another thread refreshing the lock already. If we don't
do that we might end up in a re-login loop.

If we have many threads sending requests to the APIC and the token
validity falls under the refresh threshold, multiple threads might try
to refresh the token. If now the APIC is under heavy load and takes a
long time to answer the refresh requests we might end up in a situation
where our session actually times out, triggering a re-login. Now that we
have multiple threads waiting their turn with refreshing the token, they
all try to re-login, causing the refresh time to be None (newly created
mo_dir without a logged in session), which again will cause new threads
to issue a re-login. Recomputing the token validity after acquiring the
lock should prevent that.

To better monitor cases like this we now also report if the refresh time
is None.