### PR TITLE
[GH Workflow]  Migrate to Tox 4

### DIFF
--- a/.github/workflows/run-tox.yml
+++ b/.github/workflows/run-tox.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox
-        run: pip install "tox<4.0"
+        run: pip install tox
       - name: Run Tox
         run: "tox -e py"

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,12 @@ skipsdist = True
 requires = virtualenv >= 20
 
 [testenv]
-usedevelop = True
 install_command = pip install -c {env:UPPER_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/2024.1-m3/upper-constraints.txt} -r requirements.txt -r test-requirements.txt -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
          PYTHONWARNINGS=default::DeprecationWarning
 deps = -r{toxinidir}/test-requirements.txt
-       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/2024.1-m3#egg=neutron}
+       -e{env:NEUTRON_SOURCE:git+https://github.com/sapcc/neutron.git@stable/2024.1-m3\#egg=neutron}
+       -e .
 whitelist_externals = sh
 commands = stestr run {posargs}
 download = True


### PR DESCRIPTION
PEP-660 introduced a standardized way of installing a package in development mode,
providing the same effect as if pip install -e was used.

If use_develop (defaults to false) is set, tox install the current
package in development mode using PEP 660.

With this setting enabled, our unittests fail with 'SystemExit: The following mechanism
drivers were not found: {'aci'}'.

Using 'pip install -e.' fixes this.