### PR TITLE
Only warn when trying to tag non-existent network

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/rpc_api.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/rpc_api.py
@@ -18,6 +18,7 @@ from neutron_lib.exceptions import NetworkNotFound
 from neutron_lib import rpc as n_rpc
 from neutron.extensions import tagging
 from neutron.services.tag import tag_plugin
+from oslo_db import exception as db_exc
 from oslo_log import log as logging
 from oslo_log import helpers as log_helpers
 import oslo_messaging
@@ -197,6 +198,9 @@ class AgentRpcCallback(object):
             LOG.info("Tagging attempt resulted in stale data error on DB access for network {}, "
                      "network may have been deleted concurrently."
                      .format(network_id))
+        except db_exc.DBReferenceError as e:
+            LOG.warning("Could not tag Network %s with %s due to DBReferenceError - network might already be deleted? "
+                        "(error was: %s)", network_id, tag, e)
 
     def get_az_aware_subnet_routes(self, rpc_context):
         subnets = []


### PR DESCRIPTION
When the agent tries to tag a network via RPC that does no longer exist, we used to get a DBReferenceError like this:

Cannot add or update a child row: a foreign key constraint fails (`neutron`.`tags`, CONSTRAINT `tags_ibfk_1` FOREIGN KEY (`standard_attr_id`) REFERENCES `standardattributes` (`id`) ON DELETE CASCADE)

This means the standardattributes belonging to the network have been deleted (alongside with the network). This is something we can just ignore, as we don't need to tag something that is already gone and the agent will never ask for it again. Therefore we write out a warning (in case someone ever DOES have a problem with this) and carry one as usual.