### PR TITLE
[Fix] Baremetal deployment

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/allocations_manager.py
@@ -253,7 +253,7 @@ class AllocationsManager(object):
             return True
 
     @db_api.retry_db_errors
-    def allocate_baremetal_segment(self, context, network, hostgroup, level, segmentation_id):
+    def allocate_baremetal_segment(self, network, hostgroup, level, segmentation_id):
         """Allocate a "baremetal segment" (with or without pre-specified id)
 
         Baremetal segments are dynamically allocated based on their physnet (physnet name will be
@@ -316,7 +316,7 @@ class AllocationsManager(object):
             # 2. sanity checks
             if is_access:
                 # for access mode: check that no other network has bound this in host mode
-                host_segments = self.db.get_hosts_on_physnet(context, segment_physnet, level=1,
+                host_segments = self.db.get_hosts_on_physnet(ctx, segment_physnet, level=1,
                                                              with_segment=True, with_segmentation=True)
                 for far_host, far_segment_id, far_segmentation_id in host_segments:
                     if far_host in hostgroup['hosts'] and far_segmentation_id in access_id_pool:

--- a/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
@@ -167,7 +167,7 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
                 segmentation_id = port['binding:profile'][aci_const.TRUNK_PROFILE].get('segmentation_id', 1)
             else:
                 segmentation_id = None  # let the allocater choose a vlan
-            allocation = self.allocations_manager.allocate_baremetal_segment(context._plugin_context, network,
+            allocation = self.allocations_manager.allocate_baremetal_segment(network,
                                                                              hostgroup, level, segmentation_id)
             segment_id = allocation.id
             segmentation_id = allocation.segmentation_id


### PR DESCRIPTION
The migration to the new sql enginefacade of neutron lib breaks baremetal deployment as the context object does not have a method 'get_admin_context'. To overcome this we fetch a fresh Context from neutron lib.