### PR TITLE
Fix CODEOWNERS rule order to ensure correct precedence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/.github/CODEOWNERS @sapcc/cc_github_managers_approval
 * @sapcc/network-api-contributors @sapcc/cc_github_managers_approval
+/.github/CODEOWNERS @sapcc/cc_github_managers_approval


### PR DESCRIPTION
The order of the rules in a CODEOWNERS file is important as the last matching pattern takes precedence. This patch corrects the CODEOWNERS file introduced in #84 by placing the default (*) rule first, allowing more specific patterns to override it as intended.