### PR TITLE
Fix set_hostgroup_mode() baremetal race condition

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/agent/cobra_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/agent/cobra_manager.py
@@ -12,10 +12,13 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import time
+
 from cobra.model import fv, fvns, infra, ip, phys, rtctrl
 import cobra.modelimpl.l3ext.out
 import netaddr
 from neutron_lib.api.definitions import availability_zone as az_def
+from oslo_concurrency import lockutils
 from oslo_config import cfg
 from oslo_log import log
 
@@ -297,20 +300,30 @@ class CobraManager(object):
             LOG.info("No port selectors configured for hostgroup %s %s, skipping hostgroup mode configuration",
                      host_config['name'], source)
             return
-        if host_config['hostgroup_mode'] == aci_const.MODE_BAREMETAL:
-            if not self.ensure_baremetal_entities(host_config['pc_policy_group'],
-                                                  host_config['baremetal_resource_name'],
-                                                  host_config['baremetal_pc_policy_group']):
-                LOG.error("Could not create baremetal entities for hostgroup %s %s",
-                          host_config['name'], source)
 
-        port_sel_entities = self._gen_port_selector_entities(host_config)
-        if not port_sel_entities:
-            LOG.error("No port selector entity configuration could be generated for hostgroup %s %s"
-                      " - are there configuration entities missing?",
-                      host_config['name'], source)
-            return
-        self.apic.commit(port_sel_entities)
+        lock_name = f"bm-hg-mode-{host_config['name']}"
+        lock_time_start = time.monotonic()
+        LOG.info("Setting hostgroup mode for %s to %s", host_config['name'], host_config['hostgroup_mode'])
+        with lockutils.lock(lock_name, fair=True):
+            lock_time_acquired = time.monotonic()
+            if lock_time_acquired - lock_time_start >= 10.0:
+                LOG.warning("Needed to wait %.2fs for lock %s in ensure_hostgroup_mode_config()",
+                            lock_time_acquired - lock_time_start, lock_name)
+            if host_config['hostgroup_mode'] == aci_const.MODE_BAREMETAL:
+                if not self.ensure_baremetal_entities(host_config['pc_policy_group'],
+                                                      host_config['baremetal_resource_name'],
+                                                      host_config['baremetal_pc_policy_group']):
+                    LOG.error("Could not create baremetal entities for hostgroup %s %s",
+                              host_config['name'], source)
+
+            port_sel_entities = self._gen_port_selector_entities(host_config)
+            if not port_sel_entities:
+                LOG.error("No port selector entity configuration could be generated for hostgroup %s %s"
+                          " - are there configuration entities missing?",
+                          host_config['name'], source)
+                return
+            self.apic.commit(port_sel_entities)
+        LOG.debug("Lock %s released after %.2f", lock_name, time.monotonic() - lock_time_acquired)
 
     def create_subnet(self, subnet, external, address_scope_name, network_az):
         self._configure_subnet(subnet, external=external, address_scope_name=address_scope_name, network_az=network_az,

--- a/networking_aci/plugins/ml2/drivers/mech_aci/agent/cobra_manager.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/agent/cobra_manager.py
@@ -315,6 +315,7 @@ class CobraManager(object):
                                                       host_config['baremetal_pc_policy_group']):
                     LOG.error("Could not create baremetal entities for hostgroup %s %s",
                               host_config['name'], source)
+                    return
 
             port_sel_entities = self._gen_port_selector_entities(host_config)
             if not port_sel_entities:

--- a/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/agent/test_cobra_manager.py
+++ b/networking_aci/tests/unit/plugins/ml2/drivers/mech_aci/agent/test_cobra_manager.py
@@ -1,0 +1,110 @@
+# Copyright 2026 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import sys
+import threading
+import time
+
+import mock
+from neutron.tests import base
+from oslo_config import cfg
+
+from networking_aci.tests.unit import utils
+
+
+for mod in ['cobra', 'cobra.mit', 'cobra.mit.access', 'cobra.mit.session',
+            'cobra.mit.request', 'cobra.model', 'cobra.model.fv',
+            'cobra.model.fvns', 'cobra.model.infra', 'cobra.model.ip',
+            'cobra.model.phys', 'cobra.model.rtctrl',
+            'cobra.modelimpl.l3ext.out']:
+    sys.modules.setdefault(mod, mock.MagicMock())
+
+# import after cobra mocks
+from networking_aci.plugins.ml2.drivers.mech_aci.agent.entry_point import register_options
+from networking_aci.plugins.ml2.drivers.mech_aci.agent.cobra_manager import CobraManager
+
+
+class TestCobraManager(base.BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        register_options()
+        utils.setup_aci_config(cfg)
+
+        with mock.patch('networking_aci.plugins.ml2.drivers.mech_aci.agent.cobra_client.CobraClient') as mock_client:
+            self.mgr = CobraManager(agent_plugin=mock.MagicMock(), tenant_manager=mock.MagicMock())
+        self.mgr.apic = mock_client.return_value
+
+        self.host_config = {
+            'name': 'herring-gull-hg',
+            'hostgroup_mode': 'baremetal',
+            'port_selectors': ['uni/infra/accportprof-hg1/hports-sel1-typ-range'],
+            'pc_policy_group': 'bm-9001g',
+            'baremetal_resource_name': 'hg1-bm',
+            'baremetal_pc_policy_group': 'hg1-bm-bundle',
+        }
+
+    def test_setting_hostgroup_mode_calls_are_sequential(self):
+        # testplan:
+        #   get first thread into apic commit
+        #   start second thread
+        #   ...wait fixed amount of time
+        #   release first thread from apic commit
+        #   check if second thread actually waited for first thread
+        first_commit = threading.Event()
+        first_commit_cond = threading.Condition()
+        commit_count = 0
+        first_commit_time = None
+        second_commit_time = None
+
+        def apic_commit_mock(entities):
+            nonlocal commit_count, first_commit_time, second_commit_time
+
+            if commit_count == 0:
+                commit_count += 1
+                first_commit.set()
+                with first_commit_cond:
+                    first_commit_cond.wait()
+                first_commit_time = time.monotonic()
+            elif commit_count == 1:
+                commit_count += 1
+                second_commit_time = time.monotonic()
+            else:
+                raise Exception("Too many commits")
+
+        self.mgr.apic.commit.side_effect = apic_commit_mock
+        self.mgr.ensure_baremetal_entities = mock.MagicMock(return_value=True)
+        self.mgr._gen_port_selector_entities = mock.MagicMock(return_value=['entity1'])
+
+        def run():
+            self.mgr.ensure_hostgroup_mode_config(self.host_config, source="the-beach")
+
+        # start first thread, wait for it to be in apic.commit()
+        t1 = threading.Thread(target=run, daemon=True)
+        t1.start()
+        first_commit.wait()
+
+        # start second thread, give it a short time to run into the lock
+        t2 = threading.Thread(target=run, daemon=True)
+        t2.start()
+        time.sleep(0.1)
+
+        # release the first thread
+        with first_commit_cond:
+            first_commit_cond.notify()
+
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        self.assertEqual(2, self.mgr.apic.commit.call_count)
+        self.assertLess(first_commit_time, second_commit_time)


### PR DESCRIPTION
This commit fixes a race condition where two entities try to set the hostgroup mode for the same hostgroup, which can result in the first call overwriting the result of the second call.

When we deploy baremetal instances, they get two sets of ports: one for deployment and one for the customer network. The customer ports are created in DOWN mode and only get bound once set up. When the deployment is finished, we delete the deployment ports and set the customer ports to UP. For baremetal on ACI we reset the binding mode from baremetal mode (scoped to a project) to infra mode (not scoped to a project) so we can remove project-scoped entities in the APIC and the project-scoped network segment in OpenStack. Both cases are handled by set_hostgroup_mode(). In cases where we have a very slow APIC (or the APIC is slow for some requests, fast for others), the set_hostgroup_mode() call for resetting a VPC to infra mode might take longer than the call for setting everything up for the new project, which results in the customer port being unusable (due to being in wrong mode). This is then fixed the next time the network is synced via API or via syncloop (which might take up to two hours, depending on where the syncloop currently is).

To prevent this, we introduce one lock guarding the whole set_hostgroup_mode() logic (at least the parts that interact with the APIC). We use a fair lock to ensure the unlock order is in the order threads try to acquire the lock. We don't need to use an external lock, as the ACI agent consists of only a single process. With this, the second call should wait for the first to finish.

This is under the assumption that the slow part is the APIC, which so far the logs have confirmed. It does not protect against wrong API use or against a very slow neutron-server instance not sending out the RPC call. Another solution to this would probably be to make all our ACI agent RPC calls synchronous, but this would also result in the binding process being very slow in high-load regions.