### PR TITLE
Disallow external subnet creation in tagged pools

### DIFF
--- a/networking_aci/plugins/ml2/drivers/mech_aci/constants.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/constants.py
@@ -29,3 +29,4 @@ CC_FABRIC_NET_GW = 'cc-fabric-network-gateway'
 AZ_TAG_PREFIX = 'availability-zone::'
 
 CC_FABRIC_L3_GATEWAY_TAG = 'gateway-host::cc-fabric'
+SNP_EXT_NET_ADMIN_ONLY = 'ext-net-admin-only'

--- a/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/driver.py
@@ -450,10 +450,10 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
         cannot block.  Raising an exception will result in a rollback
         of the current transaction.
         """
-        self._check_external_subnet_requires_address_scope(context)
+        self._check_external_subnet_subnetpool_valid(context)
         self._check_subnet_and_subnetpool_az_match(context)
 
-    def _check_external_subnet_requires_address_scope(self, context):
+    def _check_external_subnet_subnetpool_valid(self, context):
         if not CONF.ml2_aci.external_subnet_requires_address_scope_enabled:
             return
 
@@ -461,9 +461,17 @@ class CiscoACIMechanismDriver(api.MechanismDriver):
         if not net[extnet_def.EXTERNAL]:
             return
 
+        # require subnet pool with an address scope
         snp_id = context.current['subnetpool_id']
         if snp_id is None or self.db.get_address_scope_name(context._plugin_context, snp_id) is None:
             raise aci_exc.ExternalSubnetRequiresAddressScopeError(network_id=net['id'], subnetpool_id=snp_id)
+
+        if not context._plugin_context.is_admin:
+            # check if subnet pool is tagged to disallow non-admin users using it
+            snp = self.db.get_subnetpool(context._plugin_context, snp_id)
+            if aci_const.SNP_EXT_NET_ADMIN_ONLY in snp['tags']:
+                raise aci_exc.SubnetPoolExternalNetworkForAdminsOnlyError(
+                    subnetpool_id=snp_id, subnetpool_tag=aci_const.SNP_EXT_NET_ADMIN_ONLY)
 
     def _check_subnet_and_subnetpool_az_match(self, context):
         if not CONF.ml2_aci.subnet_subnetpool_az_check_enabled:

--- a/networking_aci/plugins/ml2/drivers/mech_aci/exceptions.py
+++ b/networking_aci/plugins/ml2/drivers/mech_aci/exceptions.py
@@ -89,3 +89,8 @@ class SubnetSubnetPoolAZAffinityError(exceptions.BadRequest):
 class ExternalSubnetRequiresAddressScopeError(exceptions.BadRequest):
     message = ("Subnet on external network %(network_id)s must use a subnetpool with an address scope, "
                "but subnetpool %(subnetpool_id)s has no address scope set")
+
+
+class SubnetPoolExternalNetworkForAdminsOnlyError(exceptions.BadRequest):
+    message = ("Subnet pool %(subnetpool_id)s cannot be used by non-admin users as a pool for "
+               "subnets of external networks (disallowed by tag %(subnetpool_tag)s)")


### PR DESCRIPTION
Introduce a subnet precommit hook to disallow creating subnets inside external networks that reference a subnet pool with the tag ext-net-admin-only for normal users.

As an upcoming feature non-admin users will be able to create external networks. This only works, if they have the subnet pool shared into the user's projects, so we can control who can create external networks for this. With IPv6 this does not work anymore, as there we need to also share the address scope to the user project. To still have control which subnet pool can actually be used for external network creation we now can tag pools with ext-net-admin-only.